### PR TITLE
Fix: fix warning for tool name

### DIFF
--- a/internal/az/registry.go
+++ b/internal/az/registry.go
@@ -1,6 +1,8 @@
 package az
 
 import (
+	"strings"
+
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -9,6 +11,12 @@ type AksCommand struct {
 	Name        string
 	Description string
 	ArgsExample string // Example of command arguments
+}
+
+// replaceSpacesWithUnderscores converts spaces to underscores
+// to create a valid tool name that follows the [a-z0-9_-] pattern
+func replaceSpacesWithUnderscores(s string) string {
+	return strings.ReplaceAll(s, " ", "_")
 }
 
 // // RegisterAz registers the generic az tool
@@ -24,7 +32,10 @@ type AksCommand struct {
 
 // RegisterAzCommand registers a specific az command as an MCP tool
 func RegisterAzCommand(cmd AksCommand) mcp.Tool {
+	// Convert spaces to underscores for valid tool name
 	commandName := cmd.Name
+	validToolName := replaceSpacesWithUnderscores(commandName)
+
 	description := "Run " + cmd.Name + " command: " + cmd.Description + "."
 
 	// Add example if available, with proper punctuation
@@ -32,7 +43,7 @@ func RegisterAzCommand(cmd AksCommand) mcp.Tool {
 		description += "\nExample: `" + cmd.ArgsExample + "`"
 	}
 
-	return mcp.NewTool(commandName,
+	return mcp.NewTool(validToolName,
 		mcp.WithDescription(description),
 		mcp.WithString("args",
 			mcp.Required(),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -76,6 +76,7 @@ func (s *Service) Run() error {
 func (s *Service) registerAzCommands() {
 	// Register read-only az commands (available at all access levels)
 	for _, cmd := range az.GetReadOnlyAzCommands() {
+		log.Println("Registering az command:", cmd.Name)
 		azTool := az.RegisterAzCommand(cmd)
 		commandExecutor := az.CreateCommandExecutorFunc(cmd.Name)
 		s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
@@ -85,6 +86,7 @@ func (s *Service) registerAzCommands() {
 	if s.cfg.AccessLevel == "readwrite" || s.cfg.AccessLevel == "admin" {
 		// Register read-write az commands
 		for _, cmd := range az.GetReadWriteAzCommands() {
+			log.Println("Registering az command:", cmd.Name)
 			azTool := az.RegisterAzCommand(cmd)
 			commandExecutor := az.CreateCommandExecutorFunc(cmd.Name)
 			s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
@@ -95,6 +97,7 @@ func (s *Service) registerAzCommands() {
 	if s.cfg.AccessLevel == "admin" {
 		// Register admin az commands
 		for _, cmd := range az.GetAdminAzCommands() {
+			log.Println("Registering az command:", cmd.Name)
 			azTool := az.RegisterAzCommand(cmd)
 			commandExecutor := az.CreateCommandExecutorFunc(cmd.Name)
 			s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))


### PR DESCRIPTION
To fix the warning for invalid tool name.

warning example:
2025-06-12 08:41:07.484 [warning] Tool "az aks browse" is invalid. Tools names may only contain [a-z0-9_-]