### PR TITLE
Chore: harden validation logic for readonly operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Go binary
+aks-mcp

--- a/internal/security/validator_test.go
+++ b/internal/security/validator_test.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -195,5 +196,250 @@ func TestAccessLevelValidation(t *testing.T) {
 				t.Errorf("validateAccessLevel() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestIsReadOperation_HelpFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		expected bool
+	}{
+		{
+			name:     "create with --help should be read-only",
+			command:  "az aks create --help",
+			expected: true,
+		},
+		{
+			name:     "delete with -h should be read-only",
+			command:  "az aks delete -h",
+			expected: true,
+		},
+		{
+			name:     "nodepool add with --help should be read-only",
+			command:  "az aks nodepool add --help",
+			expected: true,
+		},
+		{
+			name:     "command ending with -h should be read-only",
+			command:  "az aks create -h",
+			expected: true,
+		},
+		{
+			name:     "command with -h in middle should be read-only",
+			command:  "az aks create -h --name test",
+			expected: true,
+		},
+		{
+			name:     "command with --help in middle should be read-only",
+			command:  "az aks nodepool delete --help --cluster-name test",
+			expected: true,
+		},
+		{
+			name:     "command with -h as part of argument value should not be read-only",
+			command:  "az aks create --name cluster-h --resource-group rg",
+			expected: false,
+		},
+		{
+			name:     "command with help substring in argument should not be read-only",
+			command:  "az aks create --name helpful-cluster --resource-group rg",
+			expected: false,
+		},
+	}
+
+	validator := NewValidator(&SecurityConfig{})
+	// Use minimal allowed operations for testing
+	allowedOps := []string{"az aks show", "az aks list"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validator.isReadOperation(tt.command, allowedOps)
+			if result != tt.expected {
+				t.Errorf("isReadOperation(%q) = %v, expected %v", tt.command, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsReadOperation_TrustedAccessCommands(t *testing.T) {
+	validator := NewValidator(&SecurityConfig{})
+
+	// Get the actual read operations from the validator
+	readOps := AzReadOperations
+
+	tests := []struct {
+		name     string
+		command  string
+		expected bool
+	}{
+		{
+			name:     "trustedaccess rolebinding list should be read-only",
+			command:  "az aks trustedaccess rolebinding list",
+			expected: true,
+		},
+		{
+			name:     "trustedaccess rolebinding list with args should be read-only",
+			command:  "az aks trustedaccess rolebinding list --cluster-name test --resource-group rg",
+			expected: true,
+		},
+		{
+			name:     "trustedaccess rolebinding show should be read-only",
+			command:  "az aks trustedaccess rolebinding show",
+			expected: true,
+		},
+		{
+			name:     "trustedaccess rolebinding show with args should be read-only",
+			command:  "az aks trustedaccess rolebinding show --cluster-name test --name binding",
+			expected: true,
+		},
+		{
+			name:     "trustedaccess rolebinding create should not be read-only",
+			command:  "az aks trustedaccess rolebinding create --cluster-name test",
+			expected: false,
+		},
+		{
+			name:     "trustedaccess rolebinding delete should not be read-only",
+			command:  "az aks trustedaccess rolebinding delete --cluster-name test",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validator.isReadOperation(tt.command, readOps)
+			if result != tt.expected {
+				t.Errorf("isReadOperation(%q) = %v, expected %v", tt.command, result, tt.expected)
+
+				// Debug: let's see what base command is being extracted
+				cmdParts := strings.Fields(tt.command)
+				var baseCommand string
+				if len(cmdParts) >= 3 && cmdParts[0] == CommandTypeAz {
+					baseCommand = strings.Join(cmdParts[:3], " ")
+				}
+				t.Logf("Extracted base command: %q", baseCommand)
+
+				// Check if it's in the allowed operations
+				found := false
+				for _, allowed := range readOps {
+					if baseCommand == allowed || strings.HasPrefix(baseCommand, allowed) {
+						found = true
+						t.Logf("Matched against allowed operation: %q", allowed)
+						break
+					}
+				}
+				if !found {
+					t.Logf("No match found in allowed operations")
+				}
+			}
+		})
+	}
+}
+
+func TestIsReadOperation_LongCommands(t *testing.T) {
+	validator := NewValidator(&SecurityConfig{})
+	readOps := AzReadOperations
+
+	tests := []struct {
+		name     string
+		command  string
+		expected bool
+	}{
+		{
+			name:     "check-network outbound should be read-only",
+			command:  "az aks check-network outbound --name test --resource-group rg",
+			expected: true,
+		},
+		{
+			name:     "nodepool get-upgrades should be read-only",
+			command:  "az aks nodepool get-upgrades --cluster-name test --name pool1",
+			expected: true,
+		},
+		{
+			name:     "addon list should be read-only",
+			command:  "az aks addon list --name test --resource-group rg",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validator.isReadOperation(tt.command, readOps)
+			if result != tt.expected {
+				t.Errorf("isReadOperation(%q) = %v, expected %v", tt.command, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateCommand_WithHelpFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		accessLevel string
+		command     string
+		expectError bool
+	}{
+		{
+			name:        "readonly mode allows write commands with --help",
+			accessLevel: "readonly",
+			command:     "az aks create --help",
+			expectError: false,
+		},
+		{
+			name:        "readonly mode allows write commands with -h",
+			accessLevel: "readonly",
+			command:     "az aks delete -h",
+			expectError: false,
+		},
+		{
+			name:        "readonly mode allows nodepool commands with --help",
+			accessLevel: "readonly",
+			command:     "az aks nodepool add --help",
+			expectError: false,
+		},
+		{
+			name:        "readonly mode blocks write commands without help",
+			accessLevel: "readonly",
+			command:     "az aks create --name test",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := NewValidator(&SecurityConfig{AccessLevel: tt.accessLevel})
+			err := validator.ValidateCommand(tt.command, CommandTypeAz)
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none for command: %q", tt.command)
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v for command: %q", err, tt.command)
+			}
+		})
+	}
+}
+
+func TestSpecificTrustedAccessFix(t *testing.T) {
+	validator := NewValidator(&SecurityConfig{})
+	readOps := AzReadOperations
+
+	// Test the specific case that was failing
+	command := "az aks trustedaccess rolebinding list --cluster-name test"
+	result := validator.isReadOperation(command, readOps)
+
+	if !result {
+		t.Errorf("Expected trustedaccess rolebinding list to be read-only, but got false")
+
+		// Debug output
+		cmdParts := strings.Fields(command)
+		t.Logf("Command parts: %v", cmdParts)
+
+		for _, allowed := range readOps {
+			if strings.Contains(allowed, "trustedaccess") {
+				t.Logf("Found allowed trustedaccess command: %q", allowed)
+				allowedParts := strings.Fields(allowed)
+				t.Logf("Allowed parts: %v", allowedParts)
+			}
+		}
 	}
 }


### PR DESCRIPTION
This pull request enhances the `Validator` class to improve the handling of read-only operations, particularly for commands containing help flags and complex command structures. It also introduces comprehensive unit tests to validate these changes. 

### Enhancements to `Validator` logic:
* Updated `isReadOperation` in `internal/security/validator.go` to:
  - Automatically treat commands with help flags (`--help` or `-h`) as read-only.
  - Improve command matching by supporting longer and more complex command structures, ensuring accurate validation against allowed operations.

### Unit test additions:
* Added new test cases in `internal/security/validator_test.go` to verify:
  - Proper handling of help flags in commands, ensuring they are identified as read-only.
  - Validation of complex and specific command scenarios, such as trusted access commands and long command structures.
  - Behavior of `ValidateCommand` for commands with help flags under different access levels.
  - Fixes for previously failing cases, with additional debug logging for troubleshooting.

These changes improve the robustness and accuracy of access level validation, ensuring better security and usability.