### PR TITLE
Add prompts folder and monitoringservice prompt

### DIFF
--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,61 @@
+# AKS-MCP Prompts Folder
+
+This folder includes all the prompts for the AKS-MCP server. These prompt files are designed for generating the functionality of the AKS-MCP (Azure Kubernetes Service - Model Context Protocol) server with AI assistants.
+
+
+## Existing Files
+
+### Current Prompt Files
+
+- **`README.md`** - This file, describing the prompts folder and its contents
+- **`monitoringservice.md`** - Feature requirements and implementation details for MCP monitoring service integration
+
+### File Structure
+
+```
+prompts/
+├── README.md                    # This documentation file
+└── monitoringservice.md        # Monitoring service integration requirements
+```
+
+## AKS-MCP Server Capabilities
+
+The prompts in this folder are designed to test and validate the following AKS-MCP server capabilities:
+
+### Core AKS Operations
+- Cluster information retrieval and management
+- AKS cluster listing and discovery across subscriptions
+- Cluster health status and monitoring
+- Node and resource management
+
+### Network Operations
+- Virtual Network (VNet) information and configuration
+- Subnet details and IP address management
+- Network Security Group (NSG) rules and policies
+- Route table information and network routing
+- Load balancer and ingress configuration
+
+### Monitoring and Observability
+- Azure Monitor integration and dashboard access
+- Log Analytics workspace queries and log retrieval
+- Application Insights performance monitoring and tracing
+- Alert management and notification systems
+- Performance metrics collection and analysis
+- Real-time monitoring and data visualization
+
+### Security and Access Control
+- Access level validation (readonly, readwrite, admin)
+- Security policy enforcement and validation
+- Authentication and authorization testing
+- Role-based access control (RBAC) verification
+
+## Adding New Prompt Files
+
+When adding new prompt files to this folder:
+
+1. **Follow naming conventions**: Use descriptive, lowercase names with hyphens (e.g., `cluster-operations.md`)
+2. **Include clear objectives**: Each file should specify what functionality it tests
+3. **Provide expected behaviors**: Document what responses are expected for each prompt
+4. **Add prerequisites**: List any required setup, permissions, or resources
+5. **Update this README**: Add the new file to the "Existing Files" section above
+

--- a/prompts/monitoringservice.md
+++ b/prompts/monitoringservice.md
@@ -1,0 +1,26 @@
+Feature: Add MCP (Monitoring Control Plane) server
+// Description:
+// Implement a service (MCP server) that connects to any attached monitoring services for a given AKS cluster.
+// The server should expose APIs or a UI to perform the following tasks:
+//
+// 1. Read and query Azure Log Analytics workspaces linked to the cluster:
+// - Retrieve control plane logs
+// - Query audit logs
+// - Fetch historical logs for nodes and pods
+//
+// 2. Read and visualize metrics from Managed Prometheus (AMP):
+// - Access Prometheus scrape endpoint via Azure Monitor
+// - Display basic dashboard visualizations (e.g., CPU, memory, network)
+//
+// 3. Access and query Application Insights:
+// - Read distributed trace data
+// - Enable filtering by operation name, request ID, service name, etc.
+//
+// Requirements:
+// - Use Azure SDKs (Go or Python preferred)
+// - Support authentication via kubeconfig or managed identity
+// - Implement minimal RESTful API to trigger each of the above
+
+//
+// Goal:
+// Provide a dev-friendly mcp implementation for AKS clusters with access to log/metric/trace data via attached services.


### PR DESCRIPTION
- Add prompts/README.md with complete documentation for the prompts folder
- Add prompts/monitoringservice.md with MCP monitoring service feature requirements
-- Include guidelines for adding new prompt files and contribution standards

The prompts folder serves as the central location for all AKS-MCP server prompts files.