### PR TITLE
add Azure Advisor prompt for AKS-MCP

### DIFF
--- a/prompts/README.md
+++ b/prompts/README.md
@@ -10,6 +10,7 @@ This folder includes all the prompts for the AKS-MCP server. These prompt files 
 - **`README.md`** - This file, describing the prompts folder and its contents
 - **`monitoringservice.md`** - Feature requirements and implementation details for MCP monitoring service integration
 - **`azure-diagnostics.md`** - Implementation specifications for Azure diagnostic and advisory tools (AppLens detectors, Resource Health, Azure Advisor)
+- **`azure-advisor.md`** - Focused implementation specifications for Azure Advisor recommendations integration
 
 ### File Structure
 
@@ -17,7 +18,8 @@ This folder includes all the prompts for the AKS-MCP server. These prompt files 
 prompts/
 ├── README.md                    # This documentation file
 ├── monitoringservice.md        # Monitoring service integration requirements
-└── azure-diagnostics.md        # Azure diagnostics and advisory tools specifications
+├── azure-diagnostics.md        # Azure diagnostics and advisory tools specifications
+└── azure-advisor.md            # Azure Advisor recommendations integration
 ```
 
 ## AKS-MCP Server Capabilities

--- a/prompts/azure-advisor.md
+++ b/prompts/azure-advisor.md
@@ -1,0 +1,99 @@
+# Azure Advisor Tool for AKS-MCP
+
+Implement Azure Advisor recommendation capabilities for AKS clusters and related resources.
+
+## Tool: `az_advisor_recommendation`
+
+**Purpose**: Retrieve and manage Azure Advisor recommendations for AKS clusters
+
+**Parameters**:
+- `operation` (required): `list`, `details`, or `report`
+- `subscription_id` (required): Azure subscription ID
+- `resource_group` (optional): Filter by resource group
+- `cluster_names` (optional): Array of AKS cluster names to filter
+- `category` (optional): `Cost`, `HighAvailability`, `Performance`, `Security`
+- `severity` (optional): `High`, `Medium`, `Low`
+- `recommendation_id` (optional): Required for `details` operation
+
+**Operations**:
+- **list**: Return AKS-related recommendations with basic details
+- **details**: Get comprehensive information for a specific recommendation
+- **report**: Generate summary report of AKS recommendations by category
+
+## Implementation Steps
+
+1. **Execute Azure CLI commands** to retrieve recommendations
+2. **Parse JSON output** from Azure CLI responses
+3. **Filter for AKS resources** (managedClusters, agentPools, related networking)
+4. **Handle errors** gracefully with meaningful messages
+5. **Return structured JSON** matching expected output format
+
+## Key Azure CLI Commands
+
+```bash
+# List recommendations
+az advisor recommendation list --subscription {sub} --output json
+
+# Get specific recommendation
+az advisor recommendation show --recommendation-id {id} --output json
+
+# Filter by category and resource group
+az advisor recommendation list --category Cost --resource-group {rg} --output json
+```
+- Handle errors gracefully with meaningful messages
+
+### AKS Resource Filtering
+Filter recommendations for:
+- `Microsoft.ContainerService/managedClusters`
+- `Microsoft.ContainerService/managedClusters/agentPools`
+- Kubernetes-related load balancers and public IPs
+
+## Code Structure Requirements
+
+### File Organization
+```
+internal/azure/advisor/
+├── cli_client.go          # Azure CLI command execution
+├── aks_recommendations.go # AKS-specific filtering and processing
+├── reports.go            # Report generation
+└── types.go              # Data types
+```
+
+### Tool Registration
+```go
+func (s *Server) registerAdvisorTools() {
+    s.registerTool("az_advisor_recommendation", s.handleAdvisorRecommendation)
+}
+```
+
+## Access Level Requirements
+- **Readonly**: All operations (list, details, report)
+- **Readwrite**: Enhanced filtering and custom reports
+
+## Access Levels
+
+- **Readonly**: All operations supported
+- **Readwrite**: Enhanced filtering options
+- **Admin**: Same as readwrite (no admin-specific operations)
+
+## Expected Integration
+
+- Add tool registration in `internal/server/server.go`
+- Create handlers in `internal/azure/advisor/` directory
+- Follow existing error handling patterns
+- Use standard JSON output format
+
+## Success Criteria
+- ✅ Retrieve Azure Advisor recommendations for AKS resources
+- ✅ Filter by category, severity, and AKS clusters
+- ✅ Provide actionable implementation guidance
+- ✅ Generate comprehensive advisory reports
+- ✅ Handle errors gracefully with proper authentication
+
+## Implementation Priority
+1. Basic recommendation listing with AKS filtering
+2. Detailed recommendation information
+3. Report generation and data aggregation
+4. Performance optimization and caching
+
+Generate the implementation following these high-level specifications.


### PR DESCRIPTION
- Add azure-advisor.md with high-level implementation instructions
- Focus on AKS-specific Azure Advisor recommendations
- Include unified tool (az_advisor_recommendation) with three operations
- Support list, details, and report operations for AKS clusters
- Use Azure CLI commands for all operations
- Update README.md to document new prompt file