### PR TITLE
Add support for Kubectl commands

### DIFF
--- a/internal/az/executor.go
+++ b/internal/az/executor.go
@@ -28,9 +28,15 @@ func (e *AzExecutor) Execute(params map[string]interface{}, cfg *config.ConfigDa
 		return "", fmt.Errorf("invalid command parameter")
 	}
 
+	// Determine command type based on the command prefix
+	commandType := security.CommandTypeAz
+	if strings.HasPrefix(azCmd, "kubectl") {
+		commandType = security.CommandTypeKubectl
+	}
+
 	// Validate the command against security settings
 	validator := security.NewValidator(cfg.SecurityConfig)
-	err := validator.ValidateCommand(azCmd, security.CommandTypeAz)
+	err := validator.ValidateCommand(azCmd, commandType)
 	if err != nil {
 		return "", err
 	}
@@ -50,9 +56,9 @@ func (e *AzExecutor) Execute(params map[string]interface{}, cfg *config.ConfigDa
 		cmdArgs = strings.Join(cmdParts[1:], " ")
 	}
 
-	// If the command is not an az command, return an error
-	if binaryName != "az" {
-		return "", fmt.Errorf("command must start with 'az'")
+	// Validate binary name
+	if binaryName != "az" && binaryName != "kubectl" {
+		return "", fmt.Errorf("command must start with 'az' or 'kubectl'")
 	}
 
 	// Execute the command
@@ -72,9 +78,15 @@ func (e *AzExecutor) ExecuteSpecificCommand(cmd string, params map[string]interf
 		fullCmd += " " + args
 	}
 
+	// Determine command type based on the command prefix
+	commandType := security.CommandTypeAz
+	if strings.HasPrefix(fullCmd, "kubectl") {
+		commandType = security.CommandTypeKubectl
+	}
+
 	// Validate the command against security settings
 	validator := security.NewValidator(cfg.SecurityConfig)
-	err := validator.ValidateCommand(fullCmd, security.CommandTypeAz)
+	err := validator.ValidateCommand(fullCmd, commandType)
 	if err != nil {
 		return "", err
 	}
@@ -94,9 +106,9 @@ func (e *AzExecutor) ExecuteSpecificCommand(cmd string, params map[string]interf
 		cmdArgs = strings.Join(cmdParts[1:], " ")
 	}
 
-	// If the command is not an az command, return an error
-	if binaryName != "az" {
-		return "", fmt.Errorf("command must start with 'az'")
+	// Validate binary name
+	if binaryName != "az" && binaryName != "kubectl" {
+		return "", fmt.Errorf("command must start with 'az' or 'kubectl'")
 	}
 
 	// Execute the command

--- a/internal/az/registry.go
+++ b/internal/az/registry.go
@@ -168,3 +168,21 @@ func GetAdminAzCommands() []AksCommand {
 		// {Name: "az aks update-credentials", Description: "Update credentials for a managed Kubernetes cluster", ArgsExample: "--name myAKSCluster --resource-group myResourceGroup --reset-service-principal --service-principal CLIENT_ID --client-secret CLIENT_SECRET"},
 	}
 }
+
+// GetKubectlCommands returns kubectl commands for browsing Kubernetes resources
+func GetKubectlCommands() []AksCommand {
+	return []AksCommand{
+		// Resource listing and getting
+		{Name: "kubectl get", Description: "List or get Kubernetes resources (pods, services, deployments, nodes, namespaces, etc.)", ArgsExample: "pods -n kube-system -o wide"},
+		{Name: "kubectl describe", Description: "Show detailed information about specific Kubernetes resources", ArgsExample: "pod my-pod-name -n default"},
+		
+		// Logs and debugging
+		{Name: "kubectl logs", Description: "Print container logs from pods", ArgsExample: "my-pod-name -n default --tail=100 --follow=false"},
+		{Name: "kubectl top", Description: "Display resource usage (CPU/Memory) for nodes or pods", ArgsExample: "nodes"},
+		
+		// Cluster information
+		{Name: "kubectl cluster-info", Description: "Display cluster information and component statuses", ArgsExample: ""},
+		{Name: "kubectl api-resources", Description: "List all available API resources in the cluster", ArgsExample: "--namespaced=true"},
+		{Name: "kubectl version", Description: "Display client and server Kubernetes version", ArgsExample: "--short"},
+	}
+}

--- a/internal/security/validator.go
+++ b/internal/security/validator.go
@@ -6,7 +6,8 @@ import (
 
 // Command type constants
 const (
-	CommandTypeAz = "az"
+	CommandTypeAz      = "az"
+	CommandTypeKubectl = "kubectl"
 )
 
 var (
@@ -58,6 +59,27 @@ var (
 		"az resource list",
 		"az resource show",
 	}
+
+	// KubectlReadOperations defines kubectl operations that don't modify state
+	KubectlReadOperations = []string{
+		// Resource listing and getting
+		"kubectl get",
+		"kubectl describe",
+		
+		// Logs and debugging
+		"kubectl logs",
+		"kubectl top",
+		
+		// Cluster information
+		"kubectl cluster-info",
+		"kubectl api-resources",
+		"kubectl version",
+		"kubectl config",
+		
+		// Other read-only operations
+		"kubectl explain",
+		"kubectl api-versions",
+	}
 )
 
 // Validator handles validation of commands against security configuration
@@ -86,6 +108,8 @@ func (v *Validator) getReadOperationsList(commandType string) []string {
 	switch commandType {
 	case CommandTypeAz:
 		return AzReadOperations
+	case CommandTypeKubectl:
+		return KubectlReadOperations
 	default:
 		return []string{}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,6 +46,9 @@ func (s *Service) Initialize() error {
 	// Register individual az commands
 	s.registerAzCommands()
 
+	// Register kubectl commands for Kubernetes resource browsing
+	s.registerKubectlCommands()
+
 	// Register Azure resource tools (VNet, NSG, etc.)
 	s.registerAzureResourceTools()
 
@@ -115,6 +118,18 @@ func (s *Service) registerAzCommands() {
 			commandExecutor := az.CreateCommandExecutorFunc(cmd.Name)
 			s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
 		}
+	}
+}
+
+// registerKubectlCommands registers kubectl commands for browsing Kubernetes resources
+func (s *Service) registerKubectlCommands() {
+	// Check if kubectl commands should be available based on access level
+	// kubectl commands are read-only by default, so available at all access levels
+	for _, cmd := range az.GetKubectlCommands() {
+		log.Println("Registering kubectl command:", cmd.Name)
+		kubectlTool := az.RegisterAzCommand(cmd)
+		commandExecutor := az.CreateCommandExecutorFunc(cmd.Name)
+		s.mcpServer.AddTool(kubectlTool, tools.CreateToolHandler(commandExecutor, s.cfg))
 	}
 }
 


### PR DESCRIPTION
This pull request introduces support for handling `kubectl` commands alongside existing `az` commands in the application. The changes include updates to command validation, registration, and execution logic, as well as the addition of read-only `kubectl` operations to enhance functionality while maintaining security.

### Support for `kubectl` Commands:

* **Command Type Handling**: Introduced a new `CommandTypeKubectl` constant and updated the `AzExecutor` methods to determine the command type dynamically based on the command prefix (`az` or `kubectl`). This ensures appropriate validation for each command type. (`internal/az/executor.go`: [[1]](diffhunk://#diff-7da825b702442c40586216b625ffcae768642fa3ce648554f13666673a4fb6fbR31-R39) [[2]](diffhunk://#diff-7da825b702442c40586216b625ffcae768642fa3ce648554f13666673a4fb6fbR81-R89); `internal/security/validator.go`: [[3]](diffhunk://#diff-0b5c9d54cd55c7adda866558dd4f233c2510c05affd89e1cf7444e1b6d9fcbedR10)

* **Validation Updates**: Extended the `Validator` to support `kubectl` commands by defining a `KubectlReadOperations` list and updating the `getReadOperationsList` method to include `kubectl` operations. This ensures only read-only `kubectl` commands are allowed. (`internal/security/validator.go`: [[1]](diffhunk://#diff-0b5c9d54cd55c7adda866558dd4f233c2510c05affd89e1cf7444e1b6d9fcbedR66-R86) [[2]](diffhunk://#diff-0b5c9d54cd55c7adda866558dd4f233c2510c05affd89e1cf7444e1b6d9fcbedR115-R116)

### Command Registration and Execution:

* **Command Registration**: Added a new `registerKubectlCommands` method in the `Service` class to register `kubectl` commands. These commands are read-only by default and are available at all access levels. (`internal/server/server.go`: [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R49-R51) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R127-R138)

* **Command Registry**: Created a `GetKubectlCommands` function to define and return a list of supported `kubectl` commands, including resource listing, logs, and cluster information. (`internal/az/registry.go`: [internal/az/registry.goR171-R188](diffhunk://#diff-36d1beceb0c46288d561db2fd472845476cc12a0b1013865da4edaf473dadbadR171-R188))

### Validation Improvements:

* **Binary Name Validation**: Updated binary name validation logic in `AzExecutor` to allow both `az` and `kubectl` commands, ensuring commands are properly restricted to supported binaries. (`internal/az/executor.go`: [[1]](diffhunk://#diff-7da825b702442c40586216b625ffcae768642fa3ce648554f13666673a4fb6fbL53-R61) [[2]](diffhunk://#diff-7da825b702442c40586216b625ffcae768642fa3ce648554f13666673a4fb6fbL97-R111)

## Screenshots
![image](https://github.com/user-attachments/assets/b7c9f71c-e5f2-4592-bc76-a477700a4a60)
![image](https://github.com/user-attachments/assets/a633ffaf-53f7-49d3-923f-60d20c319d36)
![image](https://github.com/user-attachments/assets/18dbd71a-fe0c-4f3c-94dc-634f0ccc9850)
