### PR TITLE
feat: add az fleet commands and registration functionality

### DIFF
--- a/internal/components/fleet/registry.go
+++ b/internal/components/fleet/registry.go
@@ -1,0 +1,100 @@
+package fleet
+
+import (
+	"github.com/Azure/aks-mcp/internal/utils"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// FleetCommand defines a specific az fleet command to be registered as a tool
+type FleetCommand struct {
+	Name        string
+	Description string
+	ArgsExample string // Example of command arguments
+}
+
+// RegisterFleet registers the generic az fleet tool
+func RegisterFleet() mcp.Tool {
+	return mcp.NewTool("az-fleet",
+		mcp.WithDescription("Run az fleet commands for Azure Kubernetes Service Fleet management"),
+		mcp.WithString("command",
+			mcp.Required(),
+			mcp.Description("The az fleet command to execute (e.g., 'az fleet list', 'az fleet show --name myFleet --resource-group myRG')"),
+		),
+	)
+}
+
+// RegisterFleetCommand registers a specific az fleet command as an MCP tool
+func RegisterFleetCommand(cmd FleetCommand) mcp.Tool {
+	// Convert spaces to underscores for valid tool name
+	commandName := cmd.Name
+	validToolName := utils.ReplaceSpacesWithUnderscores(commandName)
+
+	description := "Run " + cmd.Name + " command: " + cmd.Description + "."
+
+	// Add example if available
+	if cmd.ArgsExample != "" {
+		description += "\nExample: `" + cmd.ArgsExample + "`"
+	}
+
+	return mcp.NewTool(validToolName,
+		mcp.WithDescription(description),
+		mcp.WithString("args",
+			mcp.Required(),
+			mcp.Description("Arguments for the `"+cmd.Name+"` command"),
+		),
+	)
+}
+
+// GetReadOnlyFleetCommands returns all read-only fleet commands
+func GetReadOnlyFleetCommands() []FleetCommand {
+	return []FleetCommand{
+		// Fleet commands
+		{Name: "az fleet list", Description: "List all fleets", ArgsExample: "--resource-group myResourceGroup"},
+		{Name: "az fleet show", Description: "Show details of a specific fleet", ArgsExample: "--name myFleet --resource-group myResourceGroup"},
+		
+		// Fleet member commands
+		{Name: "az fleet member list", Description: "List all members of a fleet", ArgsExample: "--fleet-name myFleet --resource-group myResourceGroup"},
+		{Name: "az fleet member show", Description: "Show details of a specific fleet member", ArgsExample: "--name myMember --fleet-name myFleet --resource-group myResourceGroup"},
+		
+		// Update run commands
+		{Name: "az fleet updaterun list", Description: "List all update runs for a fleet", ArgsExample: "--fleet-name myFleet --resource-group myResourceGroup"},
+		{Name: "az fleet updaterun show", Description: "Show details of a specific update run", ArgsExample: "--name myUpdateRun --fleet-name myFleet --resource-group myResourceGroup"},
+		
+		// Update strategy commands
+		{Name: "az fleet updatestrategy list", Description: "List all update strategies for a fleet", ArgsExample: "--fleet-name myFleet --resource-group myResourceGroup"},
+		{Name: "az fleet updatestrategy show", Description: "Show details of a specific update strategy", ArgsExample: "--name myStrategy --fleet-name myFleet --resource-group myResourceGroup"},
+	}
+}
+
+// GetReadWriteFleetCommands returns all read-write fleet commands
+func GetReadWriteFleetCommands() []FleetCommand {
+	return []FleetCommand{
+		// Fleet management
+		{Name: "az fleet create", Description: "Create a new fleet", ArgsExample: "--name myFleet --resource-group myResourceGroup --location eastus"},
+		{Name: "az fleet update", Description: "Update a fleet", ArgsExample: "--name myFleet --resource-group myResourceGroup --tags environment=production"},
+		{Name: "az fleet delete", Description: "Delete a fleet", ArgsExample: "--name myFleet --resource-group myResourceGroup --yes"},
+		
+		// Fleet member management
+		{Name: "az fleet member create", Description: "Add a member to a fleet", ArgsExample: "--name myMember --fleet-name myFleet --resource-group myResourceGroup --member-cluster-id /subscriptions/.../managedClusters/myCluster"},
+		{Name: "az fleet member update", Description: "Update a fleet member", ArgsExample: "--name myMember --fleet-name myFleet --resource-group myResourceGroup --update-group staging"},
+		{Name: "az fleet member delete", Description: "Remove a member from a fleet", ArgsExample: "--name myMember --fleet-name myFleet --resource-group myResourceGroup --yes"},
+		
+		// Update run management
+		{Name: "az fleet updaterun create", Description: "Create a new update run", ArgsExample: "--name myUpdateRun --fleet-name myFleet --resource-group myResourceGroup --upgrade-type Full --kubernetes-version 1.28.0"},
+		{Name: "az fleet updaterun start", Description: "Start an update run", ArgsExample: "--name myUpdateRun --fleet-name myFleet --resource-group myResourceGroup"},
+		{Name: "az fleet updaterun stop", Description: "Stop an update run", ArgsExample: "--name myUpdateRun --fleet-name myFleet --resource-group myResourceGroup"},
+		{Name: "az fleet updaterun delete", Description: "Delete an update run", ArgsExample: "--name myUpdateRun --fleet-name myFleet --resource-group myResourceGroup --yes"},
+		
+		// Update strategy management
+		{Name: "az fleet updatestrategy create", Description: "Create a new update strategy", ArgsExample: "--name myStrategy --fleet-name myFleet --resource-group myResourceGroup --stages stage1"},
+		{Name: "az fleet updatestrategy delete", Description: "Delete an update strategy", ArgsExample: "--name myStrategy --fleet-name myFleet --resource-group myResourceGroup --yes"},
+	}
+}
+
+// GetAdminFleetCommands returns all admin fleet commands
+func GetAdminFleetCommands() []FleetCommand {
+	return []FleetCommand{
+		// Currently no admin-only fleet commands defined
+		// Admin users get all readwrite commands by default
+	}
+}

--- a/internal/components/fleet/registry_test.go
+++ b/internal/components/fleet/registry_test.go
@@ -1,0 +1,103 @@
+package fleet
+
+import (
+	"testing"
+)
+
+func TestGetReadOnlyFleetCommands_ContainsBasicCommands(t *testing.T) {
+	commands := GetReadOnlyFleetCommands()
+
+	// Check that basic fleet commands are included
+	foundFleetList := false
+	foundFleetShow := false
+
+	for _, cmd := range commands {
+		if cmd.Name == "az fleet list" {
+			foundFleetList = true
+			if cmd.Description == "" {
+				t.Error("Expected fleet list command to have a description")
+			}
+			if cmd.ArgsExample == "" {
+				t.Error("Expected fleet list command to have an args example")
+			}
+		}
+		if cmd.Name == "az fleet show" {
+			foundFleetShow = true
+			if cmd.Description == "" {
+				t.Error("Expected fleet show command to have a description")
+			}
+			if cmd.ArgsExample == "" {
+				t.Error("Expected fleet show command to have an args example")
+			}
+		}
+	}
+
+	if !foundFleetList {
+		t.Error("Expected to find 'az fleet list' command in read-only commands")
+	}
+
+	if !foundFleetShow {
+		t.Error("Expected to find 'az fleet show' command in read-only commands")
+	}
+}
+
+func TestRegisterFleetCommand_BasicCommands(t *testing.T) {
+	// Test that fleet list command can be registered
+	listCmd := FleetCommand{
+		Name:        "az fleet list",
+		Description: "List all fleets",
+		ArgsExample: "--resource-group myResourceGroup",
+	}
+
+	tool := RegisterFleetCommand(listCmd)
+
+	if tool.Name != "az_fleet_list" {
+		t.Errorf("Expected tool name 'az_fleet_list', got '%s'", tool.Name)
+	}
+
+	if tool.Description == "" {
+		t.Error("Expected tool description to be set")
+	}
+
+	// Test that fleet member create command can be registered
+	createCmd := FleetCommand{
+		Name:        "az fleet member create",
+		Description: "Add a member to a fleet",
+		ArgsExample: "--name myMember --fleet-name myFleet --resource-group myResourceGroup",
+	}
+
+	tool2 := RegisterFleetCommand(createCmd)
+
+	if tool2.Name != "az_fleet_member_create" {
+		t.Errorf("Expected tool name 'az_fleet_member_create', got '%s'", tool2.Name)
+	}
+
+	if tool2.Description == "" {
+		t.Error("Expected tool description to be set")
+	}
+}
+
+func TestGetReadWriteFleetCommands_ContainsManagementCommands(t *testing.T) {
+	commands := GetReadWriteFleetCommands()
+
+	// Check that management commands are included
+	foundFleetCreate := false
+	foundMemberCreate := false
+
+	for _, cmd := range commands {
+		if cmd.Name == "az fleet create" {
+			foundFleetCreate = true
+		}
+		if cmd.Name == "az fleet member create" {
+			foundMemberCreate = true
+		}
+	}
+
+	if !foundFleetCreate {
+		t.Error("Expected to find 'az fleet create' command in read-write commands")
+	}
+
+	if !foundMemberCreate {
+		t.Error("Expected to find 'az fleet member create' command in read-write commands")
+	}
+}

--- a/internal/security/validator.go
+++ b/internal/security/validator.go
@@ -58,6 +58,16 @@ var (
 		"az monitor metrics list-namespaces",
 		"az monitor activity-log list",
 
+		// Azure Fleet commands (read-only)
+		"az fleet list",
+		"az fleet show",
+		"az fleet member list",
+		"az fleet member show",
+		"az fleet updaterun list",
+		"az fleet updaterun show",
+		"az fleet updatestrategy list",
+		"az fleet updatestrategy show",
+
 		// Other general commands
 		"az find",
 		"az version",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/aks-mcp/internal/azureclient"
 	"github.com/Azure/aks-mcp/internal/components/advisor"
 	"github.com/Azure/aks-mcp/internal/components/azaks"
+	"github.com/Azure/aks-mcp/internal/components/fleet"
 	"github.com/Azure/aks-mcp/internal/components/monitor"
 	"github.com/Azure/aks-mcp/internal/components/network"
 	"github.com/Azure/aks-mcp/internal/config"
@@ -101,6 +102,11 @@ func (s *Service) registerAzCommands() {
 		s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
 	}
 
+	// Register generic az fleet tool (available at all access levels)
+	log.Println("Registering az fleet tool: az-fleet")
+	fleetTool := fleet.RegisterFleet()
+	s.mcpServer.AddTool(fleetTool, tools.CreateToolHandler(azcli.NewExecutor(), s.cfg))
+
 	// Register Azure Resource Health monitoring tool (available at all access levels)
 	log.Println("Registering monitor tool: az_monitor_activity_log_resource_health")
 	resourceHealthTool := monitor.RegisterResourceHealthTool()
@@ -131,6 +137,9 @@ func (s *Service) registerAzCommands() {
 			commandExecutor := azcli.CreateCommandExecutorFunc(cmd.Name)
 			s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
 		}
+
+		// Fleet commands are handled by the generic az fleet tool registered above
+		// No additional registration needed for read-write access
 	}
 
 	// Register admin commands only if access level is admin
@@ -150,6 +159,9 @@ func (s *Service) registerAzCommands() {
 			commandExecutor := azcli.CreateCommandExecutorFunc(cmd.Name)
 			s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
 		}
+
+		// Fleet commands are handled by the generic az fleet tool registered above
+		// No additional registration needed for admin access
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a new `fleet` component to support Azure Kubernetes Service (AKS) Fleet management. It includes functionality for registering fleet-related commands, categorizing them by access level, and integrating them into the existing system. Tests were added to ensure the correctness of the new functionality.

### New Fleet Component

* [`internal/components/fleet/registry.go`](diffhunk://#diff-7a79573f8b2c01474c3d554de3afb7d396716b7cd3d1935d54f69b926475182dR1-R100): Added a new `fleet` package to define and register fleet-related commands. The package supports generic fleet tools and specific commands, categorized into read-only, read-write, and admin levels.

### Unit Tests for Fleet Commands

* [`internal/components/fleet/registry_test.go`](diffhunk://#diff-210834d2c19e472413fb01f471c326b1babb43b426a6bfd63d26f95eddfc1945R1-R103): Added tests to verify the presence of key read-only and read-write fleet commands and the correctness of command registration.

### Integration with Existing System

* [`internal/security/validator.go`](diffhunk://#diff-0b5c9d54cd55c7adda866558dd4f233c2510c05affd89e1cf7444e1b6d9fcbedR61-R70): Added read-only fleet commands to the list of valid commands for security validation.
* [`internal/server/server.go`](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R11): Integrated the `fleet` package into the server by registering the generic fleet tool and ensuring access-level-specific commands are handled appropriately. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R11) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R105-R109) [[3]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R140-R142) [[4]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R162-R164)


<img width="821" height="2034" alt="image" src="https://github.com/user-attachments/assets/e4a8cd46-ab76-474c-a11b-3be1e84928ad" />
