### PR TITLE
feat: implement AppLens detector MCP tools

### DIFF
--- a/internal/azureclient/client.go
+++ b/internal/azureclient/client.go
@@ -324,3 +324,8 @@ func (c *AzureClient) GetResourceByID(ctx context.Context, resourceID string) (i
 		return nil, fmt.Errorf("unsupported resource type: %s", parsed.ResourceType)
 	}
 }
+
+// GetCache returns the Azure cache instance
+func (c *AzureClient) GetCache() *AzureCache {
+	return c.cache
+}

--- a/internal/azureclient/detector.go
+++ b/internal/azureclient/detector.go
@@ -1,0 +1,86 @@
+package azureclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// MakeDetectorAPICall makes an HTTP request to Azure Management API for detector operations
+func (c *AzureClient) MakeDetectorAPICall(ctx context.Context, url string, subscriptionID string) (*http.Response, error) {
+	// Create HTTP client with Azure authentication
+	client := &http.Client{}
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// Get access token for the request
+	token, err := c.credential.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://management.azure.com/.default"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access token: %v", err)
+	}
+
+	// Set headers
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "AKS-MCP")
+
+	// Make the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %v", err)
+	}
+
+	return resp, nil
+}
+
+// ParseResourceID extracts subscription, resource group, and cluster name from AKS resource ID
+func ParseAKSResourceID(resourceID string) (subscriptionID, resourceGroup, clusterName string, err error) {
+	// Expected format: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{clusterName}
+	parts := strings.Split(strings.TrimPrefix(resourceID, "/"), "/")
+
+	if len(parts) < 8 || !strings.EqualFold(parts[0], "subscriptions") || !strings.EqualFold(parts[2], "resourceGroups") ||
+		!strings.EqualFold(parts[4], "providers") || !strings.EqualFold(parts[5], "Microsoft.ContainerService") || !strings.EqualFold(parts[6], "managedClusters") {
+		return "", "", "", fmt.Errorf("invalid AKS resource ID format: %s", resourceID)
+	}
+
+	subscriptionID = parts[1]
+	resourceGroup = parts[3]
+	clusterName = parts[7]
+
+	return subscriptionID, resourceGroup, clusterName, nil
+}
+
+// HandleDetectorAPIResponse reads and handles the response from detector API calls
+func HandleDetectorAPIResponse(resp *http.Response) ([]byte, error) {
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errorMsg map[string]interface{}
+		if err := json.Unmarshal(body, &errorMsg); err == nil {
+			if msg, ok := errorMsg["error"].(map[string]interface{}); ok {
+				if message, ok := msg["message"].(string); ok {
+					return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, message)
+				}
+			}
+		}
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}

--- a/internal/azureclient/detector.go
+++ b/internal/azureclient/detector.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 
@@ -63,7 +64,11 @@ func ParseAKSResourceID(resourceID string) (subscriptionID, resourceGroup, clust
 
 // HandleDetectorAPIResponse reads and handles the response from detector API calls
 func HandleDetectorAPIResponse(resp *http.Response) ([]byte, error) {
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("Warning: failed to close response body: %v", err)
+		}
+	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/components/detectors/client.go
+++ b/internal/components/detectors/client.go
@@ -1,0 +1,141 @@
+package detectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/Azure/aks-mcp/internal/azureclient"
+)
+
+// DetectorClient wraps Azure API calls with caching
+type DetectorClient struct {
+	azClient *azureclient.AzureClient
+	cache    *azureclient.AzureCache
+}
+
+// NewDetectorClient creates a new detector client
+func NewDetectorClient(azClient *azureclient.AzureClient) *DetectorClient {
+	return &DetectorClient{
+		azClient: azClient,
+		cache:    azClient.GetCache(),
+	}
+}
+
+// ListDetectors lists all detectors for a cluster with caching
+func (c *DetectorClient) ListDetectors(ctx context.Context, subscriptionID, resourceGroup, clusterName string) (*DetectorListResponse, error) {
+	// Create cache key
+	cacheKey := fmt.Sprintf("detectors:list:%s:%s:%s", subscriptionID, resourceGroup, clusterName)
+	
+	// Check cache first
+	if cached, found := c.cache.Get(cacheKey); found {
+		if detectors, ok := cached.(*DetectorListResponse); ok {
+			return detectors, nil
+		}
+	}
+
+	// Build API URL
+	apiURL := fmt.Sprintf("https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s/detectors?api-version=2024-08-01",
+		url.PathEscape(subscriptionID),
+		url.PathEscape(resourceGroup),
+		url.PathEscape(clusterName))
+
+	// Make API call
+	resp, err := c.azClient.MakeDetectorAPICall(ctx, apiURL, subscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call detector list API: %v", err)
+	}
+
+	// Handle response
+	body, err := azureclient.HandleDetectorAPIResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to handle detector list response: %v", err)
+	}
+
+	// Parse response
+	var detectorList DetectorListResponse
+	if err := json.Unmarshal(body, &detectorList); err != nil {
+		return nil, fmt.Errorf("failed to parse detector list response: %v", err)
+	}
+
+	// Cache the result
+	c.cache.Set(cacheKey, &detectorList)
+
+	return &detectorList, nil
+}
+
+// RunDetector executes a specific detector
+func (c *DetectorClient) RunDetector(ctx context.Context, subscriptionID, resourceGroup, clusterName, detectorName, startTime, endTime string) (*DetectorRunResponse, error) {
+	// Build API URL with query parameters
+	apiURL := fmt.Sprintf("https://management.azure.com/subscriptions/%s/resourcegroups/%s/providers/microsoft.containerservice/managedclusters/%s/detectors/%s?startTime=%s&endTime=%s&api-version=2024-08-01",
+		url.PathEscape(subscriptionID),
+		url.PathEscape(resourceGroup),
+		url.PathEscape(clusterName),
+		url.PathEscape(detectorName),
+		url.QueryEscape(startTime),
+		url.QueryEscape(endTime))
+
+	// Make API call
+	resp, err := c.azClient.MakeDetectorAPICall(ctx, apiURL, subscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call detector run API: %v", err)
+	}
+
+	// Handle response
+	body, err := azureclient.HandleDetectorAPIResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to handle detector run response: %v", err)
+	}
+
+	// Parse response
+	var detectorRun DetectorRunResponse
+	if err := json.Unmarshal(body, &detectorRun); err != nil {
+		return nil, fmt.Errorf("failed to parse detector run response: %v", err)
+	}
+
+	return &detectorRun, nil
+}
+
+// GetDetectorsByCategory filters detectors by category from cached list
+func (c *DetectorClient) GetDetectorsByCategory(ctx context.Context, subscriptionID, resourceGroup, clusterName, category string) ([]Detector, error) {
+	// Get full detector list (will use cache if available)
+	detectorList, err := c.ListDetectors(ctx, subscriptionID, resourceGroup, clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get detector list: %v", err)
+	}
+
+	// Filter by category
+	var filteredDetectors []Detector
+	for _, detector := range detectorList.Value {
+		if strings.EqualFold(detector.Properties.Metadata.Category, category) {
+			filteredDetectors = append(filteredDetectors, detector)
+		}
+	}
+
+	return filteredDetectors, nil
+}
+
+// RunDetectorsByCategory executes all detectors in a specific category
+func (c *DetectorClient) RunDetectorsByCategory(ctx context.Context, subscriptionID, resourceGroup, clusterName, category, startTime, endTime string) ([]DetectorRunResponse, error) {
+	// Get detectors by category
+	detectors, err := c.GetDetectorsByCategory(ctx, subscriptionID, resourceGroup, clusterName, category)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get detectors by category: %v", err)
+	}
+
+	// Run each detector
+	var results []DetectorRunResponse
+	for _, detector := range detectors {
+		result, err := c.RunDetector(ctx, subscriptionID, resourceGroup, clusterName, detector.Properties.Metadata.ID, startTime, endTime)
+		if err != nil {
+			// Log error but continue with other detectors
+			fmt.Printf("Failed to run detector %s: %v\n", detector.Properties.Metadata.Name, err)
+			continue
+		}
+		results = append(results, *result)
+	}
+
+	return results, nil
+}

--- a/internal/components/detectors/detectors_test.go
+++ b/internal/components/detectors/detectors_test.go
@@ -1,0 +1,108 @@
+package detectors
+
+import (
+	"testing"
+	"time"
+)
+
+func TestValidateTimeParameters(t *testing.T) {
+	now := time.Now()
+	validStart := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	validEnd := now.Format(time.RFC3339)
+	
+	tests := []struct {
+		name      string
+		startTime string
+		endTime   string
+		wantErr   bool
+	}{
+		{
+			name:      "valid time range",
+			startTime: validStart,
+			endTime:   validEnd,
+			wantErr:   false,
+		},
+		{
+			name:      "invalid start time format",
+			startTime: "invalid-time",
+			endTime:   validEnd,
+			wantErr:   true,
+		},
+		{
+			name:      "invalid end time format",
+			startTime: validStart,
+			endTime:   "invalid-time",
+			wantErr:   true,
+		},
+		{
+			name:      "end time before start time",
+			startTime: validEnd,
+			endTime:   validStart,
+			wantErr:   true,
+		},
+		{
+			name:      "time range too long (over 24h)",
+			startTime: now.Add(-25 * time.Hour).Format(time.RFC3339),
+			endTime:   now.Format(time.RFC3339),
+			wantErr:   true,
+		},
+		{
+			name:      "start time too old (over 30 days)",
+			startTime: now.AddDate(0, 0, -31).Format(time.RFC3339),
+			endTime:   now.AddDate(0, 0, -30).Format(time.RFC3339),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTimeParameters(tt.startTime, tt.endTime)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateTimeParameters() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		category string
+		wantErr  bool
+	}{
+		{
+			name:     "valid category - Best Practices",
+			category: "Best Practices",
+			wantErr:  false,
+		},
+		{
+			name:     "valid category - Node Health",
+			category: "Node Health",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid category",
+			category: "Invalid Category",
+			wantErr:  true,
+		},
+		{
+			name:     "empty category",
+			category: "",
+			wantErr:  true,
+		},
+		{
+			name:     "case sensitive validation",
+			category: "best practices",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCategory(tt.category)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateCategory() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/components/detectors/handlers.go
+++ b/internal/components/detectors/handlers.go
@@ -1,0 +1,254 @@
+package detectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/aks-mcp/internal/azureclient"
+	"github.com/Azure/aks-mcp/internal/config"
+	"github.com/Azure/aks-mcp/internal/tools"
+)
+
+// =============================================================================
+// Detector-related Handlers
+// =============================================================================
+
+// GetListDetectorsHandler returns handler for list_detectors tool
+func GetListDetectorsHandler(azClient *azureclient.AzureClient, cfg *config.ConfigData) tools.ResourceHandler {
+	return tools.ResourceHandlerFunc(func(params map[string]interface{}, _ *config.ConfigData) (string, error) {
+		return HandleListDetectors(params, NewDetectorClient(azClient))
+	})
+}
+
+// GetRunDetectorHandler returns handler for run_detector tool
+func GetRunDetectorHandler(azClient *azureclient.AzureClient, cfg *config.ConfigData) tools.ResourceHandler {
+	return tools.ResourceHandlerFunc(func(params map[string]interface{}, _ *config.ConfigData) (string, error) {
+		return HandleRunDetector(params, NewDetectorClient(azClient))
+	})
+}
+
+// GetRunDetectorsByCategoryHandler returns handler for run_detectors_by_category tool
+func GetRunDetectorsByCategoryHandler(azClient *azureclient.AzureClient, cfg *config.ConfigData) tools.ResourceHandler {
+	return tools.ResourceHandlerFunc(func(params map[string]interface{}, _ *config.ConfigData) (string, error) {
+		return HandleRunDetectorsByCategory(params, NewDetectorClient(azClient))
+	})
+}
+
+// =============================================================================
+// Handler Implementation Functions
+// =============================================================================
+
+// HandleListDetectors implements the list_detectors functionality
+func HandleListDetectors(params map[string]interface{}, client *DetectorClient) (string, error) {
+	// Extract cluster resource ID
+	clusterResourceID, ok := params["cluster_resource_id"].(string)
+	if !ok || clusterResourceID == "" {
+		return "", fmt.Errorf("missing or invalid cluster_resource_id parameter")
+	}
+
+	// Parse resource ID
+	subscriptionID, resourceGroup, clusterName, err := azureclient.ParseAKSResourceID(clusterResourceID)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse cluster resource ID: %v", err)
+	}
+
+	// List detectors
+	ctx := context.Background()
+	detectors, err := client.ListDetectors(ctx, subscriptionID, resourceGroup, clusterName)
+	if err != nil {
+		return "", fmt.Errorf("failed to list detectors: %v", err)
+	}
+
+	// Return as JSON
+	resultJSON, err := json.MarshalIndent(detectors, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal detectors to JSON: %v", err)
+	}
+
+	return string(resultJSON), nil
+}
+
+// HandleRunDetector implements the run_detector functionality
+func HandleRunDetector(params map[string]interface{}, client *DetectorClient) (string, error) {
+	// Extract cluster resource ID
+	clusterResourceID, ok := params["cluster_resource_id"].(string)
+	if !ok || clusterResourceID == "" {
+		return "", fmt.Errorf("missing or invalid cluster_resource_id parameter")
+	}
+
+	// Extract detector name
+	detectorName, ok := params["detector_name"].(string)
+	if !ok || detectorName == "" {
+		return "", fmt.Errorf("missing or invalid detector_name parameter")
+	}
+
+	// Extract start time
+	startTime, ok := params["start_time"].(string)
+	if !ok || startTime == "" {
+		return "", fmt.Errorf("missing or invalid start_time parameter")
+	}
+
+	// Extract end time
+	endTime, ok := params["end_time"].(string)
+	if !ok || endTime == "" {
+		return "", fmt.Errorf("missing or invalid end_time parameter")
+	}
+
+	// Validate time format and constraints
+	if err := validateTimeParameters(startTime, endTime); err != nil {
+		return "", fmt.Errorf("invalid time parameters: %v", err)
+	}
+
+	// Parse resource ID
+	subscriptionID, resourceGroup, clusterName, err := azureclient.ParseAKSResourceID(clusterResourceID)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse cluster resource ID: %v", err)
+	}
+
+	// Run detector
+	ctx := context.Background()
+	result, err := client.RunDetector(ctx, subscriptionID, resourceGroup, clusterName, detectorName, startTime, endTime)
+	if err != nil {
+		return "", fmt.Errorf("failed to run detector: %v", err)
+	}
+
+	// Return as JSON
+	resultJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal detector result to JSON: %v", err)
+	}
+
+	return string(resultJSON), nil
+}
+
+// HandleRunDetectorsByCategory implements the run_detectors_by_category functionality
+func HandleRunDetectorsByCategory(params map[string]interface{}, client *DetectorClient) (string, error) {
+	// Extract cluster resource ID
+	clusterResourceID, ok := params["cluster_resource_id"].(string)
+	if !ok || clusterResourceID == "" {
+		return "", fmt.Errorf("missing or invalid cluster_resource_id parameter")
+	}
+
+	// Extract category
+	category, ok := params["category"].(string)
+	if !ok || category == "" {
+		return "", fmt.Errorf("missing or invalid category parameter")
+	}
+
+	// Extract start time
+	startTime, ok := params["start_time"].(string)
+	if !ok || startTime == "" {
+		return "", fmt.Errorf("missing or invalid start_time parameter")
+	}
+
+	// Extract end time
+	endTime, ok := params["end_time"].(string)
+	if !ok || endTime == "" {
+		return "", fmt.Errorf("missing or invalid end_time parameter")
+	}
+
+	// Validate time parameters
+	if err := validateTimeParameters(startTime, endTime); err != nil {
+		return "", fmt.Errorf("invalid time parameters: %v", err)
+	}
+
+	// Validate category
+	if err := validateCategory(category); err != nil {
+		return "", fmt.Errorf("invalid category: %v", err)
+	}
+
+	// Parse resource ID
+	subscriptionID, resourceGroup, clusterName, err := azureclient.ParseAKSResourceID(clusterResourceID)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse cluster resource ID: %v", err)
+	}
+
+	// Run detectors by category
+	ctx := context.Background()
+	results, err := client.RunDetectorsByCategory(ctx, subscriptionID, resourceGroup, clusterName, category, startTime, endTime)
+	if err != nil {
+		return "", fmt.Errorf("failed to run detectors by category: %v", err)
+	}
+
+	// Create response with metadata
+	response := map[string]interface{}{
+		"category":        category,
+		"detectors_count": len(results),
+		"results":         results,
+	}
+
+	// Return as JSON
+	resultJSON, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal detector results to JSON: %v", err)
+	}
+
+	return string(resultJSON), nil
+}
+
+// =============================================================================
+// Validation Helper Functions
+// =============================================================================
+
+// validateTimeParameters validates start and end time parameters
+func validateTimeParameters(startTime, endTime string) error {
+	// Parse times
+	start, err := time.Parse(time.RFC3339, startTime)
+	if err != nil {
+		return fmt.Errorf("invalid start_time format, expected ISO 8601 (RFC3339): %v", err)
+	}
+
+	end, err := time.Parse(time.RFC3339, endTime)
+	if err != nil {
+		return fmt.Errorf("invalid end_time format, expected ISO 8601 (RFC3339): %v", err)
+	}
+
+	now := time.Now()
+	thirtyDaysAgo := now.AddDate(0, 0, -30)
+
+	// Check if times are within last 30 days
+	if start.Before(thirtyDaysAgo) {
+		return fmt.Errorf("start_time must be within the last 30 days")
+	}
+
+	if end.Before(thirtyDaysAgo) {
+		return fmt.Errorf("end_time must be within the last 30 days")
+	}
+
+	// Check if end time is after start time
+	if end.Before(start) || end.Equal(start) {
+		return fmt.Errorf("end_time must be after start_time")
+	}
+
+	// Check if duration is max 24 hours
+	if end.Sub(start) > 24*time.Hour {
+		return fmt.Errorf("time range cannot exceed 24 hours")
+	}
+
+	return nil
+}
+
+// validateCategory validates the category parameter
+func validateCategory(category string) error {
+	validCategories := []string{
+		"Best Practices",
+		"Cluster and Control Plane Availability and Performance",
+		"Connectivity Issues",
+		"Create, Upgrade, Delete and Scale",
+		"Deprecations",
+		"Identity and Security",
+		"Node Health",
+		"Storage",
+	}
+
+	for _, valid := range validCategories {
+		if strings.EqualFold(category, valid) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid category '%s', must be one of: %v", category, validCategories)
+}

--- a/internal/components/detectors/registry.go
+++ b/internal/components/detectors/registry.go
@@ -1,0 +1,67 @@
+package detectors
+
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Detector-related tool registrations
+
+// RegisterListDetectorsTool registers the list_detectors MCP tool
+func RegisterListDetectorsTool() mcp.Tool {
+	return mcp.NewTool(
+		"list_detectors",
+		mcp.WithDescription("List all available AKS cluster detectors"),
+		mcp.WithString("cluster_resource_id",
+			mcp.Description("AKS cluster resource ID"),
+			mcp.Required(),
+		),
+	)
+}
+
+// RegisterRunDetectorTool registers the run_detector MCP tool
+func RegisterRunDetectorTool() mcp.Tool {
+	return mcp.NewTool(
+		"run_detector",
+		mcp.WithDescription("Run a specific AKS detector"),
+		mcp.WithString("cluster_resource_id",
+			mcp.Description("AKS cluster resource ID"),
+			mcp.Required(),
+		),
+		mcp.WithString("detector_name",
+			mcp.Description("Name of the detector to run"),
+			mcp.Required(),
+		),
+		mcp.WithString("start_time",
+			mcp.Description("Start time in UTC ISO format (within last 30 days). Example: 2025-07-11T10:55:13Z"),
+			mcp.Required(),
+		),
+		mcp.WithString("end_time",
+			mcp.Description("End time in UTC ISO format (within last 30 days, max 24h from start). Example: 2025-07-11T14:55:13Z"),
+			mcp.Required(),
+		),
+	)
+}
+
+// RegisterRunDetectorsByCategoryTool registers the run_detectors_by_category MCP tool
+func RegisterRunDetectorsByCategoryTool() mcp.Tool {
+	return mcp.NewTool(
+		"run_detectors_by_category",
+		mcp.WithDescription("Run all detectors in a specific category"),
+		mcp.WithString("cluster_resource_id",
+			mcp.Description("AKS cluster resource ID"),
+			mcp.Required(),
+		),
+		mcp.WithString("category",
+			mcp.Description("Detector category to run (Best Practices, Cluster and Control Plane Availability and Performance, Connectivity Issues, Create/Upgrade/Delete and Scale, Deprecations, Identity and Security, Node Health, Storage)"),
+			mcp.Required(),
+		),
+		mcp.WithString("start_time",
+			mcp.Description("Start time in UTC ISO format (within last 30 days). Example: 2025-07-11T10:55:13Z"),
+			mcp.Required(),
+		),
+		mcp.WithString("end_time",
+			mcp.Description("End time in UTC ISO format (within last 30 days, max 24h from start). Example: 2025-07-11T14:55:13Z"),
+			mcp.Required(),
+		),
+	)
+}

--- a/internal/components/detectors/types.go
+++ b/internal/components/detectors/types.go
@@ -1,0 +1,80 @@
+package detectors
+
+// DetectorListResponse represents the API response for listing detectors
+type DetectorListResponse struct {
+	Value []Detector `json:"value"`
+}
+
+// Detector represents a single detector metadata
+type Detector struct {
+	ID         string             `json:"id"`
+	Name       string             `json:"name"`
+	Type       string             `json:"type"`
+	Location   string             `json:"location"`
+	Properties DetectorProperties `json:"properties"`
+}
+
+// DetectorProperties contains detector metadata
+type DetectorProperties struct {
+	Metadata DetectorMetadata `json:"metadata"`
+	Status   DetectorStatus   `json:"status"`
+}
+
+// DetectorMetadata contains detector information
+type DetectorMetadata struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+}
+
+// DetectorStatus contains detector status
+type DetectorStatus struct {
+	Message  *string `json:"message"`
+	StatusID int     `json:"statusId"`
+}
+
+// DetectorRunResponse represents the API response for running a detector
+type DetectorRunResponse struct {
+	ID         string                 `json:"id"`
+	Name       string                 `json:"name"`
+	Type       string                 `json:"type"`
+	Location   string                 `json:"location"`
+	Properties DetectorRunProperties `json:"properties"`
+}
+
+// DetectorRunProperties contains detector run results
+type DetectorRunProperties struct {
+	Dataset  []DetectorDataset `json:"dataset"`
+	Metadata DetectorMetadata  `json:"metadata"`
+	Status   DetectorStatus    `json:"status"`
+}
+
+// DetectorDataset represents detector output data
+type DetectorDataset struct {
+	RenderingProperties RenderingProperties `json:"renderingProperties"`
+	Table              DetectorTable       `json:"table"`
+}
+
+// RenderingProperties defines how to display results
+type RenderingProperties struct {
+	Description *string `json:"description"`
+	IsVisible   bool    `json:"isVisible"`
+	Title       *string `json:"title"`
+	Type        int     `json:"type"`
+}
+
+// DetectorTable contains tabular detector results
+type DetectorTable struct {
+	Columns   []DetectorColumn `json:"columns"`
+	Rows      [][]interface{}  `json:"rows"`
+	TableName string           `json:"tableName"`
+}
+
+// DetectorColumn defines table column metadata
+type DetectorColumn struct {
+	ColumnName string  `json:"columnName"`
+	ColumnType *string `json:"columnType"`
+	DataType   string  `json:"dataType"`
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/aks-mcp/internal/azureclient"
 	"github.com/Azure/aks-mcp/internal/components/advisor"
 	"github.com/Azure/aks-mcp/internal/components/azaks"
+	"github.com/Azure/aks-mcp/internal/components/detectors"
 	"github.com/Azure/aks-mcp/internal/components/monitor"
 	"github.com/Azure/aks-mcp/internal/components/network"
 	"github.com/Azure/aks-mcp/internal/config"
@@ -164,6 +165,9 @@ func (s *Service) registerAzureResourceTools() {
 	// Register Network-related tools
 	s.registerNetworkTools(azClient)
 
+	// Register Detector tools
+	s.registerDetectorTools(azClient)
+
 	// TODO: Add other resource categories in the future:
 }
 
@@ -195,6 +199,26 @@ func (s *Service) registerNetworkTools(azClient *azureclient.AzureClient) {
 	log.Println("Registering network tool: get_load_balancers_info")
 	lbTool := network.RegisterLoadBalancersInfoTool()
 	s.mcpServer.AddTool(lbTool, tools.CreateResourceHandler(network.GetLoadBalancersInfoHandler(azClient, s.cfg), s.cfg))
+}
+
+// registerDetectorTools registers all detector-related Azure resource tools
+func (s *Service) registerDetectorTools(azClient *azureclient.AzureClient) {
+	log.Println("Registering Detector tools...")
+
+	// Register list detectors tool
+	log.Println("Registering detector tool: list_detectors")
+	listTool := detectors.RegisterListDetectorsTool()
+	s.mcpServer.AddTool(listTool, tools.CreateResourceHandler(detectors.GetListDetectorsHandler(azClient, s.cfg), s.cfg))
+
+	// Register run detector tool
+	log.Println("Registering detector tool: run_detector")
+	runTool := detectors.RegisterRunDetectorTool()
+	s.mcpServer.AddTool(runTool, tools.CreateResourceHandler(detectors.GetRunDetectorHandler(azClient, s.cfg), s.cfg))
+
+	// Register run detectors by category tool
+	log.Println("Registering detector tool: run_detectors_by_category")
+	categoryTool := detectors.RegisterRunDetectorsByCategoryTool()
+	s.mcpServer.AddTool(categoryTool, tools.CreateResourceHandler(detectors.GetRunDetectorsByCategoryHandler(azClient, s.cfg), s.cfg))
 }
 
 // registerAdvisorTools registers all Azure Advisor-related tools


### PR DESCRIPTION
Fix #57 

- Add three new MCP tools: list_detectors, run_detector, run_detectors_by_category
- Implement detector client with caching support using Azure Management API
- Add comprehensive input validation for time parameters and categories
- Support AKS cluster resource ID format parsing
- Add unit tests for validation functions