### PR TITLE
Feat: support getting private endpoint info

### DIFF
--- a/internal/components/network/handlers_test.go
+++ b/internal/components/network/handlers_test.go
@@ -111,3 +111,111 @@ func TestGetLoadBalancersInfoHandler(t *testing.T) {
 	// Note: Testing with valid parameters and actual Azure client calls
 	// would require integration tests with mocked Azure services
 }
+
+// TestGetPrivateEndpointInfoHandlerValidation tests the private endpoint info handler parameter validation
+func TestGetPrivateEndpointInfoHandlerValidation(t *testing.T) {
+	t.Run("missing subscription_id parameter", func(t *testing.T) {
+		params := map[string]interface{}{
+			"resource_group": "rg-test",
+			"cluster_name":   "cluster-test",
+		}
+
+		handler := GetPrivateEndpointInfoHandler(nil, nil)
+		result, err := handler.Handle(params, nil)
+
+		if err == nil {
+			t.Error("Expected error for missing subscription_id")
+		}
+		if result != "" {
+			t.Error("Expected empty result on error")
+		}
+		if err.Error() != "missing or invalid subscription_id parameter" {
+			t.Errorf("Expected 'missing or invalid subscription_id parameter' error, got %v", err)
+		}
+	})
+
+	t.Run("missing resource_group parameter", func(t *testing.T) {
+		params := map[string]interface{}{
+			"subscription_id": "sub-123",
+			"cluster_name":    "cluster-test",
+		}
+
+		handler := GetPrivateEndpointInfoHandler(nil, nil)
+		result, err := handler.Handle(params, nil)
+
+		if err == nil {
+			t.Error("Expected error for missing resource_group")
+		}
+		if result != "" {
+			t.Error("Expected empty result on error")
+		}
+		if err.Error() != "missing or invalid resource_group parameter" {
+			t.Errorf("Expected 'missing or invalid resource_group parameter' error, got %v", err)
+		}
+	})
+
+	t.Run("missing cluster_name parameter", func(t *testing.T) {
+		params := map[string]interface{}{
+			"subscription_id": "sub-123",
+			"resource_group":  "rg-test",
+		}
+
+		handler := GetPrivateEndpointInfoHandler(nil, nil)
+		result, err := handler.Handle(params, nil)
+
+		if err == nil {
+			t.Error("Expected error for missing cluster_name")
+		}
+		if result != "" {
+			t.Error("Expected empty result on error")
+		}
+		if err.Error() != "missing or invalid cluster_name parameter" {
+			t.Errorf("Expected 'missing or invalid cluster_name parameter' error, got %v", err)
+		}
+	})
+
+	t.Run("empty subscription_id parameter", func(t *testing.T) {
+		params := map[string]interface{}{
+			"subscription_id": "",
+			"resource_group":  "rg-test",
+			"cluster_name":    "cluster-test",
+		}
+
+		handler := GetPrivateEndpointInfoHandler(nil, nil)
+		result, err := handler.Handle(params, nil)
+
+		if err == nil {
+			t.Error("Expected error for empty subscription_id")
+		}
+		if result != "" {
+			t.Error("Expected empty result on error")
+		}
+		if err.Error() != "missing or invalid subscription_id parameter" {
+			t.Errorf("Expected 'missing or invalid subscription_id parameter' error, got %v", err)
+		}
+	})
+
+	t.Run("invalid parameter types", func(t *testing.T) {
+		params := map[string]interface{}{
+			"subscription_id": 123, // Should be string
+			"resource_group":  "rg-test",
+			"cluster_name":    "cluster-test",
+		}
+
+		handler := GetPrivateEndpointInfoHandler(nil, nil)
+		result, err := handler.Handle(params, nil)
+
+		if err == nil {
+			t.Error("Expected error for invalid parameter type")
+		}
+		if result != "" {
+			t.Error("Expected empty result on error")
+		}
+		if err.Error() != "missing or invalid subscription_id parameter" {
+			t.Errorf("Expected 'missing or invalid subscription_id parameter' error, got %v", err)
+		}
+	})
+
+	// Note: Testing with valid parameters and actual Azure client calls
+	// would require integration tests with mocked Azure services
+}

--- a/internal/components/network/registry.go
+++ b/internal/components/network/registry.go
@@ -105,3 +105,23 @@ func RegisterLoadBalancersInfoTool() mcp.Tool {
 		),
 	)
 }
+
+// RegisterPrivateEndpointInfoTool registers the get_private_endpoint_info tool
+func RegisterPrivateEndpointInfoTool() mcp.Tool {
+	return mcp.NewTool(
+		"get_private_endpoint_info",
+		mcp.WithDescription("Get information about the private endpoint used by the AKS cluster (only available for private clusters)"),
+		mcp.WithString("subscription_id",
+			mcp.Description("Azure Subscription ID"),
+			mcp.Required(),
+		),
+		mcp.WithString("resource_group",
+			mcp.Description("Azure Resource Group containing the AKS cluster"),
+			mcp.Required(),
+		),
+		mcp.WithString("cluster_name",
+			mcp.Description("Name of the AKS cluster"),
+			mcp.Required(),
+		),
+	)
+}

--- a/internal/components/network/registry_test.go
+++ b/internal/components/network/registry_test.go
@@ -98,3 +98,26 @@ func TestGetSubnetInfoHandler(t *testing.T) {
 		t.Error("Expected handler to be non-nil")
 	}
 }
+
+func TestRegisterPrivateEndpointInfoTool(t *testing.T) {
+	tool := RegisterPrivateEndpointInfoTool()
+
+	if tool.Name != "get_private_endpoint_info" {
+		t.Errorf("Expected tool name 'get_private_endpoint_info', got %s", tool.Name)
+	}
+
+	if tool.Description == "" {
+		t.Error("Expected tool description to be set")
+	}
+}
+
+func TestGetPrivateEndpointInfoHandler(t *testing.T) {
+	mockClient := &azureclient.AzureClient{}
+	cfg := &config.ConfigData{}
+
+	handler := GetPrivateEndpointInfoHandler(mockClient, cfg)
+
+	if handler == nil {
+		t.Error("Expected handler to be non-nil")
+	}
+}

--- a/internal/components/network/resourcehelpers/privateendpointhelpers.go
+++ b/internal/components/network/resourcehelpers/privateendpointhelpers.go
@@ -1,0 +1,101 @@
+package resourcehelpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/aks-mcp/internal/azureclient"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
+)
+
+// GetPrivateEndpointIDFromAKS attempts to find the private endpoint associated with an AKS cluster.
+// It looks for a private endpoint named "kube-apiserver" in the cluster's node resource group.
+// Returns empty string if no private endpoint is found (indicating a non-private cluster).
+func GetPrivateEndpointIDFromAKS(
+	ctx context.Context,
+	cluster *armcontainerservice.ManagedCluster,
+	client *azureclient.AzureClient,
+) (string, error) {
+	// Ensure the cluster is valid
+	if cluster == nil || cluster.Properties == nil {
+		return "", fmt.Errorf("invalid cluster or cluster properties")
+	}
+
+	// Check if cluster has APIServerAccessProfile indicating private cluster
+	if cluster.Properties.APIServerAccessProfile == nil ||
+		cluster.Properties.APIServerAccessProfile.EnablePrivateCluster == nil ||
+		!*cluster.Properties.APIServerAccessProfile.EnablePrivateCluster {
+		// Not a private cluster, return empty string (not an error)
+		return "", nil
+	}
+
+	// Get the node resource group
+	if cluster.Properties.NodeResourceGroup == nil {
+		return "", fmt.Errorf("node resource group not found for AKS cluster")
+	}
+	nodeResourceGroup := *cluster.Properties.NodeResourceGroup
+
+	// Get subscription ID from cluster ID
+	subscriptionID := extractSubscriptionIDFromCluster(cluster)
+	if subscriptionID == "" {
+		return "", fmt.Errorf("unable to extract subscription ID from cluster")
+	}
+
+	// Look for the "kube-apiserver" private endpoint in the node resource group
+	return findPrivateEndpointInNodeResourceGroup(ctx, client, subscriptionID, nodeResourceGroup)
+}
+
+// findPrivateEndpointInNodeResourceGroup looks for the "kube-apiserver" private endpoint
+// in the specified node resource group
+func findPrivateEndpointInNodeResourceGroup(
+	ctx context.Context,
+	client *azureclient.AzureClient,
+	subscriptionID string,
+	nodeResourceGroup string,
+) (string, error) {
+	// Get clients for the subscription
+	clients, err := client.GetOrCreateClientsForSubscription(subscriptionID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get clients for subscription %s: %v", subscriptionID, err)
+	}
+
+	// List private endpoints in the node resource group
+	pager := clients.PrivateEndpointsClient.NewListPager(nodeResourceGroup, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to list private endpoints in resource group %s: %v", nodeResourceGroup, err)
+		}
+
+		for _, pe := range page.Value {
+			if pe.Name != nil && pe.ID != nil {
+				peName := *pe.Name
+				peID := *pe.ID
+
+				// Look for the "kube-apiserver" private endpoint
+				if peName == "kube-apiserver" {
+					return peID, nil
+				}
+			}
+		}
+	}
+
+	// No private endpoint found
+	return "", nil
+}
+
+// getSubscriptionFromCluster extracts the subscription ID from the cluster's ID
+func extractSubscriptionIDFromCluster(cluster *armcontainerservice.ManagedCluster) string {
+	if cluster.ID == nil {
+		return ""
+	}
+
+	parts := strings.Split(*cluster.ID, "/")
+	for i := 0; i < len(parts)-1; i++ {
+		if parts[i] == "subscriptions" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
+}

--- a/internal/components/network/resourcehelpers/privateendpointhelpers_test.go
+++ b/internal/components/network/resourcehelpers/privateendpointhelpers_test.go
@@ -1,0 +1,210 @@
+package resourcehelpers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
+)
+
+// TestGetPrivateEndpointIDFromAKS tests the private endpoint ID extraction from an AKS cluster
+func TestGetPrivateEndpointIDFromAKS(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("private cluster with EnablePrivateCluster true", func(t *testing.T) {
+		enablePrivateCluster := true
+		nodeResourceGroup := "MC_test-rg_test-cluster_eastus"
+
+		cluster := &armcontainerservice.ManagedCluster{
+			Properties: &armcontainerservice.ManagedClusterProperties{
+				APIServerAccessProfile: &armcontainerservice.ManagedClusterAPIServerAccessProfile{
+					EnablePrivateCluster: &enablePrivateCluster,
+				},
+				NodeResourceGroup: &nodeResourceGroup,
+			},
+		}
+
+		// Since we can't mock the Azure client easily, we expect this to fail with a client error
+		// but not with a "not a private cluster" error
+		privateEndpointID, err := GetPrivateEndpointIDFromAKS(ctx, cluster, nil)
+
+		// Should get an error because client is nil, but not because it's not a private cluster
+		if err == nil {
+			t.Error("Expected error for nil client")
+		}
+		if privateEndpointID != "" {
+			t.Error("Expected empty private endpoint ID on error")
+		}
+		if err.Error() == "" {
+			t.Error("Expected non-empty error message")
+		}
+	})
+
+	t.Run("public cluster with EnablePrivateCluster false", func(t *testing.T) {
+		enablePrivateCluster := false
+		nodeResourceGroup := "MC_test-rg_test-cluster_eastus"
+
+		cluster := &armcontainerservice.ManagedCluster{
+			Properties: &armcontainerservice.ManagedClusterProperties{
+				APIServerAccessProfile: &armcontainerservice.ManagedClusterAPIServerAccessProfile{
+					EnablePrivateCluster: &enablePrivateCluster,
+				},
+				NodeResourceGroup: &nodeResourceGroup,
+			},
+		}
+
+		privateEndpointID, err := GetPrivateEndpointIDFromAKS(ctx, cluster, nil)
+
+		// Should return empty string with no error for public cluster
+		if err != nil {
+			t.Errorf("Expected no error for public cluster, got %v", err)
+		}
+		if privateEndpointID != "" {
+			t.Error("Expected empty private endpoint ID for public cluster")
+		}
+	})
+
+	t.Run("cluster with nil APIServerAccessProfile", func(t *testing.T) {
+		nodeResourceGroup := "MC_test-rg_test-cluster_eastus"
+
+		cluster := &armcontainerservice.ManagedCluster{
+			Properties: &armcontainerservice.ManagedClusterProperties{
+				APIServerAccessProfile: nil,
+				NodeResourceGroup:      &nodeResourceGroup,
+			},
+		}
+
+		privateEndpointID, err := GetPrivateEndpointIDFromAKS(ctx, cluster, nil)
+
+		// Should return empty string with no error for cluster without APIServerAccessProfile
+		if err != nil {
+			t.Errorf("Expected no error for cluster without APIServerAccessProfile, got %v", err)
+		}
+		if privateEndpointID != "" {
+			t.Error("Expected empty private endpoint ID for cluster without APIServerAccessProfile")
+		}
+	})
+
+	t.Run("cluster with nil EnablePrivateCluster", func(t *testing.T) {
+		nodeResourceGroup := "MC_test-rg_test-cluster_eastus"
+
+		cluster := &armcontainerservice.ManagedCluster{
+			Properties: &armcontainerservice.ManagedClusterProperties{
+				APIServerAccessProfile: &armcontainerservice.ManagedClusterAPIServerAccessProfile{
+					EnablePrivateCluster: nil,
+				},
+				NodeResourceGroup: &nodeResourceGroup,
+			},
+		}
+
+		privateEndpointID, err := GetPrivateEndpointIDFromAKS(ctx, cluster, nil)
+
+		// Should return empty string with no error for cluster with nil EnablePrivateCluster
+		if err != nil {
+			t.Errorf("Expected no error for cluster with nil EnablePrivateCluster, got %v", err)
+		}
+		if privateEndpointID != "" {
+			t.Error("Expected empty private endpoint ID for cluster with nil EnablePrivateCluster")
+		}
+	})
+
+	t.Run("cluster with nil properties", func(t *testing.T) {
+		cluster := &armcontainerservice.ManagedCluster{
+			Properties: nil,
+		}
+
+		_, err := GetPrivateEndpointIDFromAKS(ctx, cluster, nil)
+		if err == nil {
+			t.Error("Expected error for cluster with nil properties")
+		}
+		if err.Error() != "invalid cluster or cluster properties" {
+			t.Errorf("Expected 'invalid cluster or cluster properties' error, got %v", err)
+		}
+	})
+
+	t.Run("nil cluster", func(t *testing.T) {
+		_, err := GetPrivateEndpointIDFromAKS(ctx, nil, nil)
+		if err == nil {
+			t.Error("Expected error for nil cluster")
+		}
+		if err.Error() != "invalid cluster or cluster properties" {
+			t.Errorf("Expected 'invalid cluster or cluster properties' error, got %v", err)
+		}
+	})
+
+	t.Run("private cluster with nil NodeResourceGroup", func(t *testing.T) {
+		enablePrivateCluster := true
+
+		cluster := &armcontainerservice.ManagedCluster{
+			Properties: &armcontainerservice.ManagedClusterProperties{
+				APIServerAccessProfile: &armcontainerservice.ManagedClusterAPIServerAccessProfile{
+					EnablePrivateCluster: &enablePrivateCluster,
+				},
+				NodeResourceGroup: nil,
+			},
+		}
+
+		_, err := GetPrivateEndpointIDFromAKS(ctx, cluster, nil)
+		if err == nil {
+			t.Error("Expected error for private cluster with nil NodeResourceGroup")
+		}
+		if err.Error() != "node resource group not found for AKS cluster" {
+			t.Errorf("Expected 'node resource group not found for AKS cluster' error, got %v", err)
+		}
+	})
+}
+
+// TestExtractSubscriptionIDFromCluster tests the subscription ID extraction from a cluster
+func TestExtractSubscriptionIDFromCluster(t *testing.T) {
+	t.Run("valid cluster ID", func(t *testing.T) {
+		clusterID := "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster"
+
+		cluster := &armcontainerservice.ManagedCluster{
+			ID: &clusterID,
+		}
+
+		subscriptionID := extractSubscriptionIDFromCluster(cluster)
+		expectedSubscriptionID := "12345678-1234-1234-1234-123456789012"
+
+		if subscriptionID != expectedSubscriptionID {
+			t.Errorf("Expected subscription ID %s, got %s", expectedSubscriptionID, subscriptionID)
+		}
+	})
+
+	t.Run("cluster with nil ID", func(t *testing.T) {
+		cluster := &armcontainerservice.ManagedCluster{
+			ID: nil,
+		}
+
+		subscriptionID := extractSubscriptionIDFromCluster(cluster)
+		if subscriptionID != "" {
+			t.Errorf("Expected empty subscription ID for cluster with nil ID, got %s", subscriptionID)
+		}
+	})
+
+	t.Run("cluster with invalid ID format", func(t *testing.T) {
+		clusterID := "invalid-cluster-id"
+
+		cluster := &armcontainerservice.ManagedCluster{
+			ID: &clusterID,
+		}
+
+		subscriptionID := extractSubscriptionIDFromCluster(cluster)
+		if subscriptionID != "" {
+			t.Errorf("Expected empty subscription ID for invalid cluster ID, got %s", subscriptionID)
+		}
+	})
+
+	t.Run("cluster with partial ID", func(t *testing.T) {
+		clusterID := "/subscriptions/"
+
+		cluster := &armcontainerservice.ManagedCluster{
+			ID: &clusterID,
+		}
+
+		subscriptionID := extractSubscriptionIDFromCluster(cluster)
+		if subscriptionID != "" {
+			t.Errorf("Expected empty subscription ID for partial cluster ID, got %s", subscriptionID)
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -233,6 +233,11 @@ func (s *Service) registerNetworkTools(azClient *azureclient.AzureClient) {
 	log.Println("Registering network tool: get_load_balancers_info")
 	lbTool := network.RegisterLoadBalancersInfoTool()
 	s.mcpServer.AddTool(lbTool, tools.CreateResourceHandler(network.GetLoadBalancersInfoHandler(azClient, s.cfg), s.cfg))
+
+	// Register Private Endpoint info tool
+	log.Println("Registering network tool: get_private_endpoint_info")
+	privateEndpointTool := network.RegisterPrivateEndpointInfoTool()
+	s.mcpServer.AddTool(privateEndpointTool, tools.CreateResourceHandler(network.GetPrivateEndpointInfoHandler(azClient, s.cfg), s.cfg))
 }
 
 // registerDetectorTools registers all detector-related Azure resource tools


### PR DESCRIPTION
This pull request introduces support for managing and retrieving information about private endpoints in Azure Kubernetes Service (AKS) clusters. The changes include updates to the Azure client, new helper functions for private endpoint handling, and new tools and tests for private endpoint functionality.

### Azure client updates:
* Added `PrivateEndpointsClient` to the `SubscriptionClients` struct and initialized it in `GetOrCreateClientsForSubscription`. [[1]](diffhunk://#diff-c1ff5094a99a88a9166175c4cfd96ea7c2d33cc66ee9f2d2f6dc70735eeeb286R26) [[2]](diffhunk://#diff-c1ff5094a99a88a9166175c4cfd96ea7c2d33cc66ee9f2d2f6dc70735eeeb286R109-R113) [[3]](diffhunk://#diff-c1ff5094a99a88a9166175c4cfd96ea7c2d33cc66ee9f2d2f6dc70735eeeb286R133)
* Implemented `GetPrivateEndpoint` and `GetPrivateEndpointByID` methods to retrieve private endpoint details.

### Private endpoint functionality:
* Created `GetPrivateEndpointIDFromAKS` in `resourcehelpers/privateendpointhelpers.go` to extract the private endpoint ID for AKS clusters.
* Added functionality to find private endpoints in a node resource group.

### New tools and handlers:
* Added `GetPrivateEndpointInfoHandler` to retrieve private endpoint information via a new tool `get_private_endpoint_info`. [[1]](diffhunk://#diff-02bac9384cf6395f5c0973d409cd75c42ba6b14a6a7d48b3adbc43782cbdf7e4R282-R331) [[2]](diffhunk://#diff-ad58dd2e60b7f596c9a4a68709da6b38a4c1ac04dfa1f4cc88aa4a3db44949b2R108-R127)
* Registered the new tool in the server.

### Testing:
* Added unit tests for private endpoint helper functions, including `GetPrivateEndpointIDFromAKS` and `extractSubscriptionIDFromCluster`.
* Added tests for `GetPrivateEndpointInfoHandler` to validate parameter handling and tool registration. [[1]](diffhunk://#diff-11af741ea731f404bf938d0b0148e8e3090ee7da4da686216b9bed541c4dfc89R114-R221) [[2]](diffhunk://#diff-34a5a186871a224844bf7d49e33addcb6bc5d9507536fc8ec39d1204391413a4R101-R123)