### PR TITLE
Fix: map access level to k8sSecurityConfig

### DIFF
--- a/internal/k8s/adapter.go
+++ b/internal/k8s/adapter.go
@@ -13,8 +13,9 @@ func ConvertConfig(cfg *config.ConfigData) *k8sconfig.ConfigData {
 	// Create K8s security config
 	k8sSecurityConfig := k8ssecurity.NewSecurityConfig()
 
-	// Map allowed namespaces
+	// Map allowed namespaces and access level
 	k8sSecurityConfig.SetAllowedNamespaces(cfg.AllowNamespaces)
+	k8sSecurityConfig.AccessLevel = k8ssecurity.AccessLevel(cfg.AccessLevel)
 
 	// Create K8s config
 	k8sCfg := &k8sconfig.ConfigData{


### PR DESCRIPTION
It seems we are missing mapping the access level which results in following error when creating a pod even with `admin` permissions:

```
Error: Cannot execute write or admin operations in read-only mode
```

After this change, resource creation works as expected:

```
deployment.apps/nginx created
```
