### PR TITLE
chore/inspektor-gadget: Use latest stable release if available

### DIFF
--- a/internal/components/inspektorgadget/const.go
+++ b/internal/components/inspektorgadget/const.go
@@ -43,6 +43,7 @@ const (
 	inspektorGadgetChartRelease   = "gadget"
 	inspektorGadgetChartNamespace = "gadget"
 	inspektorGadgetChartURL       = "oci://ghcr.io/inspektor-gadget/inspektor-gadget/charts/gadget"
+	inspektorGadgetReleaseURL     = "https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest"
 )
 
 // Name of the Inspektor Gadget gadgets

--- a/internal/components/inspektorgadget/handlers.go
+++ b/internal/components/inspektorgadget/handlers.go
@@ -246,7 +246,7 @@ func handleLifecycleAction(deployed bool, action string, actionParams map[string
 func handleDeployAction(actionParams map[string]interface{}, cfg *config.ConfigData) (string, error) {
 	chartVersion, ok := actionParams["chart_version"].(string)
 	if !ok || chartVersion == "" {
-		chartVersion = getChartVersionFromBuild()
+		chartVersion = getChartVersion()
 	}
 	chartUrl := fmt.Sprintf("%s:%s", inspektorGadgetChartURL, chartVersion)
 	helmArgs := fmt.Sprintf("install %s -n %s --create-namespace %s", inspektorGadgetChartRelease, inspektorGadgetChartNamespace, chartUrl)


### PR DESCRIPTION
Use the latest release if available otherwise fallback to build version. This ensures users will use the latest IG release even if it was released after aks-mcp server release, to keep the behavior aligned with manual installation. 

## Testing done

```
$ curl -s https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest | jq -r '.tag_name' | sed 's/^v//'
```