### PR TITLE
Refact: make a clear component hierarchy for tools registration

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -137,6 +137,9 @@ func (s *Service) registerAzureComponents() {
 	// Azure Advisor Component
 	s.registerAdvisorComponent()
 
+	// Register Inspektor Gadget tools for observability
+	s.registerInspektorGadgetComponent()
+
 	log.Println("Azure Components registered successfully")
 }
 
@@ -185,11 +188,8 @@ func (s *Service) registerOptionalKubernetesComponents() {
 	// Register cilium if enabled
 	s.registerCiliumComponent()
 
-	// Register Inspektor Gadget tools for observability
-	s.registerInspektorGadgetIfEnabled()
-
 	// Log if no optional components are enabled
-	if !s.cfg.AdditionalTools["helm"] && !s.cfg.AdditionalTools["cilium"] && !s.cfg.AdditionalTools["inspektor-gadget"] {
+	if !s.cfg.AdditionalTools["helm"] && !s.cfg.AdditionalTools["cilium"] {
 		log.Println("No optional Kubernetes components enabled")
 	}
 }
@@ -321,13 +321,5 @@ func (s *Service) registerCiliumComponent() {
 		ciliumTool := cilium.RegisterCilium()
 		ciliumExecutor := k8s.WrapK8sExecutor(cilium.NewExecutor())
 		s.mcpServer.AddTool(ciliumTool, tools.CreateToolHandler(ciliumExecutor, s.cfg))
-	}
-}
-
-// registerInspektorGadgetIfEnabled registers Inspektor Gadget tools if enabled
-func (s *Service) registerInspektorGadgetIfEnabled() {
-	if s.cfg.AdditionalTools["inspektor-gadget"] {
-		log.Println("Registering Kubernetes tool: inspektor-gadget")
-		s.registerInspektorGadgetComponent()
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,12 +41,26 @@ func NewService(cfg *config.ConfigData) *Service {
 
 // Initialize initializes the service
 func (s *Service) Initialize() error {
-	// Initialize configuration
+	log.Println("Initializing AKS MCP service...")
 
+	// Phase 1: Initialize core infrastructure
+	if err := s.initializeInfrastructure(); err != nil {
+		return err
+	}
+
+	// Phase 2: Register all component tools
+	s.registerAllComponents()
+
+	log.Println("AKS MCP service initialization completed successfully")
+	return nil
+}
+
+// initializeInfrastructure sets up the Azure client and MCP server
+func (s *Service) initializeInfrastructure() error {
 	// Create shared Azure client
 	azClient, err := azureclient.NewAzureClient(s.cfg)
 	if err != nil {
-		log.Fatalf("Failed to create Azure client: %v", err)
+		return fmt.Errorf("failed to create Azure client: %v", err)
 	}
 	s.azClient = azClient
 	log.Println("Azure client initialized successfully")
@@ -59,23 +73,18 @@ func (s *Service) Initialize() error {
 		server.WithLogging(),
 		server.WithRecovery(),
 	)
-
-	// Register individual az commands
-	s.registerAzCommands()
-
-	// Register Azure resource tools (VNet, NSG, etc.)
-	s.registerAzureResourceTools()
-
-	// Register Azure Advisor tools
-	s.registerAdvisorTools()
-
-	// Register Kubernetes tools
-	s.registerKubernetesTools()
-
-	// Register Inspektor Gadget tools for observability
-	s.registerInspektorGadgetTools()
+	log.Println("MCP server initialized successfully")
 
 	return nil
+}
+
+// registerAllComponents registers all component tools organized by category
+func (s *Service) registerAllComponents() {
+	// Azure Components
+	s.registerAzureComponents()
+
+	// Kubernetes Components
+	s.registerKubernetesComponents()
 }
 
 // Run starts the service with the specified transport
@@ -103,144 +112,51 @@ func (s *Service) Run() error {
 	}
 }
 
-// registerAzCommands registers AKS operations tool
-func (s *Service) registerAzCommands() {
-	// Register AKS operations tool
-	log.Println("Registering tool: az_aks_operations")
-	aksOperationsTool := azaks.RegisterAzAksOperations(s.cfg)
-	s.mcpServer.AddTool(aksOperationsTool, tools.CreateToolHandler(azaks.NewAksOperationsExecutor(), s.cfg))
+// registerAzureComponents registers all Azure tools (AKS operations, monitoring, fleet, network, compute, detectors, advisor)
+func (s *Service) registerAzureComponents() {
+	log.Println("Registering Azure Components...")
 
-	// Register monitoring tool
-	log.Println("Registering tool: az_monitoring")
-	monitoringTool := monitor.RegisterAzMonitoring()
-	s.mcpServer.AddTool(monitoringTool, tools.CreateResourceHandler(monitor.GetAzMonitoringHandler(s.azClient, s.cfg), s.cfg))
+	// AKS Operations Component
+	s.registerAksOpsComponent()
 
-	// Register generic az fleet tool with structured parameters (available at all access levels)
-	log.Println("Registering az fleet tool: az_fleet")
-	fleetTool := fleet.RegisterFleet()
-	s.mcpServer.AddTool(fleetTool, tools.CreateToolHandler(azcli.NewFleetExecutor(), s.cfg))
+	// Monitoring Component
+	s.registerMonitoringComponent()
+
+	// Fleet Management Component
+	s.registerFleetComponent()
+
+	// Network Resources Component
+	s.registerNetworkComponent()
+
+	// Compute Resources Component
+	s.registerComputeComponent()
+
+	// Detector Resources Component
+	s.registerDetectorComponent()
+
+	// Azure Advisor Component
+	s.registerAdvisorComponent()
+
+	log.Println("Azure Components registered successfully")
 }
 
-func (s *Service) registerAzureResourceTools() {
-	// Register Network-related tools
-	s.registerNetworkTools(s.azClient)
+// registerKubernetesComponents registers Kubernetes-related tools (kubectl, helm, cilium, observability)
+func (s *Service) registerKubernetesComponents() {
+	log.Println("Registering Kubernetes Components...")
 
-	// Register Detector tools
-	s.registerDetectorTools(s.azClient)
+	// Core Kubernetes Component (kubectl)
+	s.registerKubectlComponent()
 
-	// Register Compute-related tools
-	s.registerComputeTools(s.azClient)
+	// Optional Kubernetes Components (based on configuration)
+	s.registerOptionalKubernetesComponents()
 
-	// TODO: Add other resource categories in the future:
+	log.Println("Kubernetes Components registered successfully")
 }
 
-// registerNetworkTools registers the network resources tool
-func (s *Service) registerNetworkTools(azClient *azureclient.AzureClient) {
-	log.Println("Registering Network tool...")
+// registerKubectlComponent registers core kubectl commands based on access level
+func (s *Service) registerKubectlComponent() {
+	log.Println("Registering Core Kubernetes Component (kubectl)")
 
-	// Register network resources tool
-	log.Println("Registering network tool: az_network_resources")
-	networkTool := network.RegisterAzNetworkResources()
-	s.mcpServer.AddTool(networkTool, tools.CreateResourceHandler(network.GetAzNetworkResourcesHandler(azClient, s.cfg), s.cfg))
-
-}
-
-// registerDetectorTools registers all detector-related Azure resource tools
-func (s *Service) registerDetectorTools(azClient *azureclient.AzureClient) {
-	log.Println("Registering Detector tools...")
-
-	// Register list detectors tool
-	log.Println("Registering detector tool: list_detectors")
-	listTool := detectors.RegisterListDetectorsTool()
-	s.mcpServer.AddTool(listTool, tools.CreateResourceHandler(detectors.GetListDetectorsHandler(azClient, s.cfg), s.cfg))
-
-	// Register run detector tool
-	log.Println("Registering detector tool: run_detector")
-	runTool := detectors.RegisterRunDetectorTool()
-	s.mcpServer.AddTool(runTool, tools.CreateResourceHandler(detectors.GetRunDetectorHandler(azClient, s.cfg), s.cfg))
-
-	// Register run detectors by category tool
-	log.Println("Registering detector tool: run_detectors_by_category")
-	categoryTool := detectors.RegisterRunDetectorsByCategoryTool()
-	s.mcpServer.AddTool(categoryTool, tools.CreateResourceHandler(detectors.GetRunDetectorsByCategoryHandler(azClient, s.cfg), s.cfg))
-}
-
-// registerComputeTools registers all compute-related Azure resource tools (VMSS/VM)
-func (s *Service) registerComputeTools(azClient *azureclient.AzureClient) {
-	log.Println("Registering Compute tools...")
-
-	// Register AKS VMSS info tool (supports both single node pool and all node pools)
-	log.Println("Registering compute tool: get_aks_vmss_info")
-	vmssInfoTool := compute.RegisterAKSVMSSInfoTool()
-	s.mcpServer.AddTool(vmssInfoTool, tools.CreateResourceHandler(compute.GetAKSVMSSInfoHandler(azClient, s.cfg), s.cfg))
-
-	// Register read-only az vmss commands (available at all access levels)
-	for _, cmd := range compute.GetReadOnlyVmssCommands() {
-		log.Println("Registering az vmss command:", cmd.Name)
-		azTool := compute.RegisterAzComputeCommand(cmd)
-		commandExecutor := azcli.CreateCommandExecutorFunc(cmd.Name)
-		s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
-	}
-
-	// Register read-write commands if access level is readwrite or admin
-	if s.cfg.AccessLevel == "readwrite" || s.cfg.AccessLevel == "admin" {
-		// Register read-write az vmss commands
-		for _, cmd := range compute.GetReadWriteVmssCommands() {
-			log.Println("Registering az vmss command:", cmd.Name)
-			azTool := compute.RegisterAzComputeCommand(cmd)
-			commandExecutor := azcli.CreateCommandExecutorFunc(cmd.Name)
-			s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
-		}
-	}
-
-	// Register admin commands only if access level is admin
-	if s.cfg.AccessLevel == "admin" {
-		// Register admin az vmss commands
-		for _, cmd := range compute.GetAdminVmssCommands() {
-			log.Println("Registering az vmss command:", cmd.Name)
-			azTool := compute.RegisterAzComputeCommand(cmd)
-			commandExecutor := azcli.CreateCommandExecutorFunc(cmd.Name)
-			s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
-		}
-	}
-}
-
-// registerAdvisorTools registers all Azure Advisor-related tools
-func (s *Service) registerAdvisorTools() {
-	log.Println("Registering Advisor tools...")
-
-	// Register Azure Advisor recommendation tool (available at all access levels)
-	log.Println("Registering advisor tool: az_advisor_recommendation")
-	advisorTool := advisor.RegisterAdvisorRecommendationTool()
-	s.mcpServer.AddTool(advisorTool, tools.CreateResourceHandler(advisor.GetAdvisorRecommendationHandler(s.cfg), s.cfg))
-}
-
-// registerKubernetesTools registers Kubernetes-related tools (kubectl, helm, cilium)
-func (s *Service) registerKubernetesTools() {
-	log.Println("Registering Kubernetes tools...")
-
-	// Register kubectl commands based on access level
-	s.registerKubectlCommands()
-
-	// Register helm if enabled
-	if s.cfg.AdditionalTools["helm"] {
-		log.Println("Registering Kubernetes tool: helm")
-		helmTool := helm.RegisterHelm()
-		helmExecutor := k8s.WrapK8sExecutor(helm.NewExecutor())
-		s.mcpServer.AddTool(helmTool, tools.CreateToolHandler(helmExecutor, s.cfg))
-	}
-
-	// Register cilium if enabled
-	if s.cfg.AdditionalTools["cilium"] {
-		log.Println("Registering Kubernetes tool: cilium")
-		ciliumTool := cilium.RegisterCilium()
-		ciliumExecutor := k8s.WrapK8sExecutor(cilium.NewExecutor())
-		s.mcpServer.AddTool(ciliumTool, tools.CreateToolHandler(ciliumExecutor, s.cfg))
-	}
-}
-
-// registerKubectlCommands registers kubectl commands based on access level
-func (s *Service) registerKubectlCommands() {
 	// Get kubectl tools filtered by access level
 	kubectlTools := kubectl.RegisterKubectlTools(s.cfg.AccessLevel)
 
@@ -259,8 +175,27 @@ func (s *Service) registerKubectlCommands() {
 	}
 }
 
-// registerInspektorGadgetTools registers all Inspektor Gadget tools for observability
-func (s *Service) registerInspektorGadgetTools() {
+// registerOptionalKubernetesComponents registers optional Kubernetes tools based on configuration
+func (s *Service) registerOptionalKubernetesComponents() {
+	log.Println("Registering Optional Kubernetes Components")
+
+	// Register helm if enabled
+	s.registerHelmComponent()
+
+	// Register cilium if enabled
+	s.registerCiliumComponent()
+
+	// Register Inspektor Gadget tools for observability
+	s.registerInspektorGadgetIfEnabled()
+
+	// Log if no optional components are enabled
+	if !s.cfg.AdditionalTools["helm"] && !s.cfg.AdditionalTools["cilium"] && !s.cfg.AdditionalTools["inspektor-gadget"] {
+		log.Println("No optional Kubernetes components enabled")
+	}
+}
+
+// registerInspektorGadgetComponent registers Inspektor Gadget tools for observability
+func (s *Service) registerInspektorGadgetComponent() {
 	gadgetMgr, err := inspektorgadget.NewGadgetManager()
 	if err != nil {
 		log.Printf("Warning: Failed to create gadget manager: %v", err)
@@ -271,4 +206,128 @@ func (s *Service) registerInspektorGadgetTools() {
 	log.Println("Registering Inspektor Gadget Observability tool: inspektor_gadget_observability")
 	inspektorGadget := inspektorgadget.RegisterInspektorGadgetTool()
 	s.mcpServer.AddTool(inspektorGadget, tools.CreateResourceHandler(inspektorgadget.InspektorGadgetHandler(gadgetMgr, s.cfg), s.cfg))
+}
+
+// registerAksOpsComponent registers AKS operations tools
+func (s *Service) registerAksOpsComponent() {
+	log.Println("Registering AKS operations tool: az_aks_operations")
+	aksOperationsTool := azaks.RegisterAzAksOperations(s.cfg)
+	s.mcpServer.AddTool(aksOperationsTool, tools.CreateToolHandler(azaks.NewAksOperationsExecutor(), s.cfg))
+}
+
+// registerMonitoringComponent registers Azure monitoring tools
+func (s *Service) registerMonitoringComponent() {
+	log.Println("Registering monitoring tool: az_monitoring")
+	monitoringTool := monitor.RegisterAzMonitoring()
+	s.mcpServer.AddTool(monitoringTool, tools.CreateResourceHandler(monitor.GetAzMonitoringHandler(s.azClient, s.cfg), s.cfg))
+}
+
+// registerFleetComponent registers Azure fleet management tools
+func (s *Service) registerFleetComponent() {
+	log.Println("Registering fleet tool: az_fleet")
+	fleetTool := fleet.RegisterFleet()
+	s.mcpServer.AddTool(fleetTool, tools.CreateToolHandler(azcli.NewFleetExecutor(), s.cfg))
+}
+
+// registerAdvisorComponent registers Azure advisor tools
+func (s *Service) registerAdvisorComponent() {
+	log.Println("Registering advisor tool: az_advisor_recommendation")
+	advisorTool := advisor.RegisterAdvisorRecommendationTool()
+	s.mcpServer.AddTool(advisorTool, tools.CreateResourceHandler(advisor.GetAdvisorRecommendationHandler(s.cfg), s.cfg))
+}
+
+// registerNetworkComponent registers network-related Azure resource tools
+func (s *Service) registerNetworkComponent() {
+	log.Println("Registering Network Resources Component")
+
+	// Register network resources tool
+	log.Println("Registering network tool: az_network_resources")
+	networkTool := network.RegisterAzNetworkResources()
+	s.mcpServer.AddTool(networkTool, tools.CreateResourceHandler(network.GetAzNetworkResourcesHandler(s.azClient, s.cfg), s.cfg))
+}
+
+// registerComputeComponent registers compute-related Azure resource tools (VMSS/VM)
+func (s *Service) registerComputeComponent() {
+	log.Println("Registering Compute Resources Component")
+
+	// Register AKS VMSS info tool (supports both single node pool and all node pools)
+	log.Println("Registering compute tool: get_aks_vmss_info")
+	vmssInfoTool := compute.RegisterAKSVMSSInfoTool()
+	s.mcpServer.AddTool(vmssInfoTool, tools.CreateResourceHandler(compute.GetAKSVMSSInfoHandler(s.azClient, s.cfg), s.cfg))
+
+	// Register read-only az vmss commands (available at all access levels)
+	for _, cmd := range compute.GetReadOnlyVmssCommands() {
+		log.Printf("Registering az vmss command: %s (readonly)", cmd.Name)
+		azTool := compute.RegisterAzComputeCommand(cmd)
+		commandExecutor := azcli.CreateCommandExecutorFunc(cmd.Name)
+		s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
+	}
+
+	// Register read-write commands if access level is readwrite or admin
+	if s.cfg.AccessLevel == "readwrite" || s.cfg.AccessLevel == "admin" {
+		for _, cmd := range compute.GetReadWriteVmssCommands() {
+			log.Printf("Registering az vmss command: %s (readwrite)", cmd.Name)
+			azTool := compute.RegisterAzComputeCommand(cmd)
+			commandExecutor := azcli.CreateCommandExecutorFunc(cmd.Name)
+			s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
+		}
+	}
+
+	// Register admin commands only if access level is admin
+	if s.cfg.AccessLevel == "admin" {
+		for _, cmd := range compute.GetAdminVmssCommands() {
+			log.Printf("Registering az vmss command: %s (admin)", cmd.Name)
+			azTool := compute.RegisterAzComputeCommand(cmd)
+			commandExecutor := azcli.CreateCommandExecutorFunc(cmd.Name)
+			s.mcpServer.AddTool(azTool, tools.CreateToolHandler(commandExecutor, s.cfg))
+		}
+	}
+}
+
+// registerDetectorComponent registers detector-related Azure resource tools
+func (s *Service) registerDetectorComponent() {
+	log.Println("Registering Detector Resources Component")
+
+	// Register list detectors tool
+	log.Println("Registering detector tool: list_detectors")
+	listTool := detectors.RegisterListDetectorsTool()
+	s.mcpServer.AddTool(listTool, tools.CreateResourceHandler(detectors.GetListDetectorsHandler(s.azClient, s.cfg), s.cfg))
+
+	// Register run detector tool
+	log.Println("Registering detector tool: run_detector")
+	runTool := detectors.RegisterRunDetectorTool()
+	s.mcpServer.AddTool(runTool, tools.CreateResourceHandler(detectors.GetRunDetectorHandler(s.azClient, s.cfg), s.cfg))
+
+	// Register run detectors by category tool
+	log.Println("Registering detector tool: run_detectors_by_category")
+	categoryTool := detectors.RegisterRunDetectorsByCategoryTool()
+	s.mcpServer.AddTool(categoryTool, tools.CreateResourceHandler(detectors.GetRunDetectorsByCategoryHandler(s.azClient, s.cfg), s.cfg))
+}
+
+// registerHelmComponent registers helm tools if enabled
+func (s *Service) registerHelmComponent() {
+	if s.cfg.AdditionalTools["helm"] {
+		log.Println("Registering Kubernetes tool: helm")
+		helmTool := helm.RegisterHelm()
+		helmExecutor := k8s.WrapK8sExecutor(helm.NewExecutor())
+		s.mcpServer.AddTool(helmTool, tools.CreateToolHandler(helmExecutor, s.cfg))
+	}
+}
+
+// registerCiliumComponent registers cilium tools if enabled
+func (s *Service) registerCiliumComponent() {
+	if s.cfg.AdditionalTools["cilium"] {
+		log.Println("Registering Kubernetes tool: cilium")
+		ciliumTool := cilium.RegisterCilium()
+		ciliumExecutor := k8s.WrapK8sExecutor(cilium.NewExecutor())
+		s.mcpServer.AddTool(ciliumTool, tools.CreateToolHandler(ciliumExecutor, s.cfg))
+	}
+}
+
+// registerInspektorGadgetIfEnabled registers Inspektor Gadget tools if enabled
+func (s *Service) registerInspektorGadgetIfEnabled() {
+	if s.cfg.AdditionalTools["inspektor-gadget"] {
+		log.Println("Registering Kubernetes tool: inspektor-gadget")
+		s.registerInspektorGadgetComponent()
+	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,392 @@
+package server
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Azure/aks-mcp/internal/components/azaks"
+	"github.com/Azure/aks-mcp/internal/components/compute"
+	"github.com/Azure/aks-mcp/internal/config"
+	"github.com/Azure/mcp-kubernetes/pkg/kubectl"
+)
+
+// MockToolCounter tracks registered tools for testing
+type MockToolCounter struct {
+	azureTools int
+	k8sTools   int
+	toolNames  []string
+}
+
+// NewMockToolCounter creates a new mock tool counter
+func NewMockToolCounter() *MockToolCounter {
+	return &MockToolCounter{
+		toolNames: make([]string, 0),
+	}
+}
+
+// AddTool simulates adding a tool and categorizes it
+func (m *MockToolCounter) AddTool(toolName string) {
+	m.toolNames = append(m.toolNames, toolName)
+
+	// Categorize tools
+	azureToolPrefixes := []string{"az_", "azure_", "get_aks_", "list_detectors", "run_detector"}
+	k8sToolPrefixes := []string{"kubectl_", "k8s_", "helm", "cilium", "inspektor"}
+
+	isAzureTool := false
+	for _, prefix := range azureToolPrefixes {
+		if containsPrefix(toolName, prefix) {
+			m.azureTools++
+			isAzureTool = true
+			break
+		}
+	}
+
+	if !isAzureTool {
+		for _, prefix := range k8sToolPrefixes {
+			if containsPrefix(toolName, prefix) {
+				m.k8sTools++
+				break
+			}
+		}
+	}
+}
+
+// GetCounts returns the tool counts
+func (m *MockToolCounter) GetCounts() (azureTools, k8sTools int) {
+	return m.azureTools, m.k8sTools
+}
+
+// GetToolNames returns all registered tool names
+func (m *MockToolCounter) GetToolNames() []string {
+	return m.toolNames
+}
+
+// TestService tests the service initialization and expected tool counts
+func TestService(t *testing.T) {
+	// Set environment variables for testing to avoid Azure auth issues
+	_ = os.Setenv("AZURE_TENANT_ID", "test-tenant")
+	_ = os.Setenv("AZURE_CLIENT_ID", "test-client")
+	_ = os.Setenv("AZURE_CLIENT_SECRET", "test-secret")
+	_ = os.Setenv("AZURE_SUBSCRIPTION_ID", "test-subscription")
+	defer func() {
+		_ = os.Unsetenv("AZURE_TENANT_ID")
+		_ = os.Unsetenv("AZURE_CLIENT_ID")
+		_ = os.Unsetenv("AZURE_CLIENT_SECRET")
+		_ = os.Unsetenv("AZURE_SUBSCRIPTION_ID")
+	}()
+
+	tests := []struct {
+		name               string
+		accessLevel        string
+		additionalTools    map[string]bool
+		expectedAzureTools int
+		expectedK8sTools   int
+		description        string
+	}{
+		{
+			name:               "ReadOnly_NoOptional",
+			accessLevel:        "readonly",
+			additionalTools:    map[string]bool{},
+			expectedAzureTools: 7, // AKS Ops + Monitoring + Fleet + Network + Compute (VMSS Info only) + Detectors (3) + Advisor
+			expectedK8sTools:   0, // Will be calculated based on kubectl tools for readonly
+			description:        "Readonly access with no optional tools",
+		},
+		{
+			name:               "ReadWrite_NoOptional",
+			accessLevel:        "readwrite",
+			additionalTools:    map[string]bool{},
+			expectedAzureTools: 8, // Same as readonly + 1 read-write VMSS command
+			expectedK8sTools:   0, // Will be calculated based on kubectl tools for readwrite
+			description:        "Readwrite access with no optional tools",
+		},
+		{
+			name:               "Admin_NoOptional",
+			accessLevel:        "admin",
+			additionalTools:    map[string]bool{},
+			expectedAzureTools: 8, // Same as readwrite (no admin VMSS commands currently)
+			expectedK8sTools:   0, // Will be calculated based on kubectl tools for admin
+			description:        "Admin access with no optional tools",
+		},
+		{
+			name:        "ReadOnly_AllOptional",
+			accessLevel: "readonly",
+			additionalTools: map[string]bool{
+				"helm":             true,
+				"cilium":           true,
+				"inspektor-gadget": true,
+			},
+			expectedAzureTools: 7, // Same as readonly
+			expectedK8sTools:   0, // Will be calculated + 3 optional tools
+			description:        "Readonly access with all optional tools",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Calculate expected kubectl tools count
+			kubectlTools := kubectl.RegisterKubectlTools(tt.accessLevel)
+			expectedKubectlCount := len(kubectlTools)
+
+			// Add optional tools count
+			optionalToolsCount := 0
+			if tt.additionalTools["helm"] {
+				optionalToolsCount++
+			}
+			if tt.additionalTools["cilium"] {
+				optionalToolsCount++
+			}
+			if tt.additionalTools["inspektor-gadget"] {
+				optionalToolsCount++
+			}
+
+			expectedTotalK8sTools := expectedKubectlCount + optionalToolsCount
+
+			t.Logf("Test: %s", tt.description)
+			t.Logf("Expected kubectl tools for %s: %d", tt.accessLevel, expectedKubectlCount)
+			t.Logf("Expected optional tools: %d", optionalToolsCount)
+			t.Logf("Expected total K8s tools: %d", expectedTotalK8sTools)
+			t.Logf("Expected Azure tools: %d", tt.expectedAzureTools)
+
+			// Create test configuration
+			cfg := createTestConfig(tt.accessLevel, tt.additionalTools)
+
+			// Create service
+			service := NewService(cfg)
+
+			// Initialize service (this will register all tools)
+			err := service.Initialize()
+			if err != nil {
+				t.Fatalf("Failed to initialize service: %v", err)
+			}
+
+			// Verify initialization completed
+			if service.azClient == nil {
+				t.Error("Azure client should be initialized")
+			}
+			if service.mcpServer == nil {
+				t.Error("MCP server should be initialized")
+			}
+
+			t.Logf("Service initialized successfully for access level: %s", tt.accessLevel)
+		})
+	}
+}
+
+// TestComponentToolCounts tests individual component tool registration counts
+func TestComponentToolCounts(t *testing.T) {
+	t.Run("AzureComponents", func(t *testing.T) {
+		testCases := []struct {
+			component   string
+			toolCount   int
+			description string
+		}{
+			{"AKS Operations", 1, "az_aks_operations tool"},
+			{"Monitoring", 1, "az_monitoring tool"},
+			{"Fleet", 1, "az_fleet tool"},
+			{"Network", 1, "az_network_resources tool"},
+			{"Advisor", 1, "az_advisor_recommendation tool"},
+			{"Detectors", 3, "list_detectors, run_detector, run_detectors_by_category"},
+		}
+
+		for _, tc := range testCases {
+			t.Logf("Component: %s - Expected tools: %d (%s)", tc.component, tc.toolCount, tc.description)
+		}
+
+		// Test compute component separately due to access level variations
+		t.Run("ComputeComponent", func(t *testing.T) {
+			readOnlyCount := len(compute.GetReadOnlyVmssCommands()) + 1 // +1 for get_aks_vmss_info
+			readWriteCount := len(compute.GetReadWriteVmssCommands())
+			adminCount := len(compute.GetAdminVmssCommands())
+
+			t.Logf("Compute Component:")
+			t.Logf("  - Base tools (always): %d (get_aks_vmss_info)", 1)
+			t.Logf("  - Read-only VMSS commands: %d", len(compute.GetReadOnlyVmssCommands()))
+			t.Logf("  - Read-write VMSS commands: %d", readWriteCount)
+			t.Logf("  - Admin VMSS commands: %d", adminCount)
+			t.Logf("  - Total for readonly: %d", readOnlyCount)
+			t.Logf("  - Total for readwrite: %d", readOnlyCount+readWriteCount)
+			t.Logf("  - Total for admin: %d", readOnlyCount+readWriteCount+adminCount)
+		})
+	})
+
+	t.Run("KubernetesComponents", func(t *testing.T) {
+		// Test kubectl tools by access level
+		accessLevels := []string{"readonly", "readwrite", "admin"}
+		for _, level := range accessLevels {
+			kubectlTools := kubectl.RegisterKubectlTools(level)
+			t.Logf("Kubectl tools for %s access: %d", level, len(kubectlTools))
+
+			// Log individual kubectl tools
+			for _, tool := range kubectlTools {
+				t.Logf("  - %s", tool.Name)
+			}
+		}
+
+		t.Logf("Optional Kubernetes Components:")
+		t.Logf("  - Helm: 1 tool (when enabled)")
+		t.Logf("  - Cilium: 1 tool (when enabled)")
+		t.Logf("  - Inspektor Gadget: 1 tool (when enabled)")
+	})
+
+	t.Run("DetectorComponentDetails", func(t *testing.T) {
+		t.Logf("Detector Component includes:")
+		t.Logf("  1. list_detectors - Lists all available AKS cluster detectors")
+		t.Logf("  2. run_detector - Runs a specific AKS detector")
+		t.Logf("  3. run_detectors_by_category - Runs all detectors in a specific category")
+	})
+}
+
+// TestAKSOperationsAccess tests AKS operations access levels
+func TestAKSOperationsAccess(t *testing.T) {
+	accessLevels := []string{"readonly", "readwrite", "admin"}
+
+	for _, level := range accessLevels {
+		t.Run("AccessLevel_"+level, func(t *testing.T) {
+			cfg := createTestConfig(level, map[string]bool{})
+
+			// Test that AKS operations tool is registered with proper access
+			tool := azaks.RegisterAzAksOperations(cfg)
+			if tool.Name != "az_aks_operations" {
+				t.Errorf("Expected tool name 'az_aks_operations', got '%s'", tool.Name)
+			}
+
+			t.Logf("AKS operations tool registered for access level: %s", level)
+		})
+	}
+}
+
+// TestServiceInitialization tests basic service initialization
+func TestServiceInitialization(t *testing.T) {
+	// Set test environment variables
+	_ = os.Setenv("AZURE_TENANT_ID", "test-tenant")
+	_ = os.Setenv("AZURE_CLIENT_ID", "test-client")
+	_ = os.Setenv("AZURE_CLIENT_SECRET", "test-secret")
+	_ = os.Setenv("AZURE_SUBSCRIPTION_ID", "test-subscription")
+	defer func() {
+		_ = os.Unsetenv("AZURE_TENANT_ID")
+		_ = os.Unsetenv("AZURE_CLIENT_ID")
+		_ = os.Unsetenv("AZURE_CLIENT_SECRET")
+		_ = os.Unsetenv("AZURE_SUBSCRIPTION_ID")
+	}()
+
+	cfg := createTestConfig("readonly", map[string]bool{})
+	service := NewService(cfg)
+
+	// Test service creation
+	if service == nil {
+		t.Fatal("Service should not be nil")
+	}
+
+	if service.cfg != cfg {
+		t.Error("Service config should match provided config")
+	}
+
+	// Test initialization
+	err := service.Initialize()
+	if err != nil {
+		t.Fatalf("Initialize should not return error: %v", err)
+	}
+
+	// Test that infrastructure is initialized
+	if service.azClient == nil {
+		t.Error("Azure client should be initialized")
+	}
+
+	if service.mcpServer == nil {
+		t.Error("MCP server should be initialized")
+	}
+
+	t.Logf("Service initialized successfully")
+}
+
+// TestExpectedToolsByAccessLevel provides detailed breakdown of expected tools
+func TestExpectedToolsByAccessLevel(t *testing.T) {
+	accessLevels := []string{"readonly", "readwrite", "admin"}
+
+	for _, level := range accessLevels {
+		t.Run("AccessLevel_"+level, func(t *testing.T) {
+			// Azure Components (always the same count, but different capabilities)
+			azureToolsCount := 7 // Base count
+
+			// Add compute tools based on access level
+			readWriteVmssCount := len(compute.GetReadWriteVmssCommands())
+			adminVmssCount := len(compute.GetAdminVmssCommands())
+
+			if level == "readwrite" || level == "admin" {
+				azureToolsCount += readWriteVmssCount
+			}
+			if level == "admin" {
+				azureToolsCount += adminVmssCount
+			}
+
+			// Kubernetes tools
+			kubectlTools := kubectl.RegisterKubectlTools(level)
+			k8sToolsCount := len(kubectlTools)
+
+			t.Logf("=== Access Level: %s ===", level)
+			t.Logf("Azure Tools:")
+			t.Logf("  - AKS Operations: 1")
+			t.Logf("  - Monitoring: 1")
+			t.Logf("  - Fleet: 1")
+			t.Logf("  - Network: 1")
+			t.Logf("  - Compute Base: 1 (get_aks_vmss_info)")
+			t.Logf("  - Compute ReadWrite: %d", readWriteVmssCount)
+			if level == "admin" {
+				t.Logf("  - Compute Admin: %d", adminVmssCount)
+			}
+			t.Logf("  - Detectors: 3")
+			t.Logf("  - Advisor: 1")
+			t.Logf("  Total Azure Tools: %d", azureToolsCount)
+
+			t.Logf("Kubernetes Tools:")
+			t.Logf("  - Kubectl Tools: %d", k8sToolsCount)
+			t.Logf("  - Optional Tools: 0-3 (helm, cilium, inspektor-gadget)")
+
+			t.Logf("kubectl tools for %s:", level)
+			for i, tool := range kubectlTools {
+				t.Logf("  %d. %s", i+1, tool.Name)
+			}
+		})
+	}
+}
+
+// createTestConfig creates a test configuration
+func createTestConfig(accessLevel string, additionalTools map[string]bool) *config.ConfigData {
+	cfg := config.NewConfig()
+	cfg.AccessLevel = accessLevel
+	cfg.AdditionalTools = additionalTools
+	cfg.Transport = "stdio"
+	cfg.Timeout = 60
+	return cfg
+}
+
+// containsPrefix checks if a string starts with any of the given prefixes
+func containsPrefix(s string, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// BenchmarkServiceInitialization benchmarks service initialization
+func BenchmarkServiceInitialization(b *testing.B) {
+	// Set test environment variables
+	_ = os.Setenv("AZURE_TENANT_ID", "test-tenant")
+	_ = os.Setenv("AZURE_CLIENT_ID", "test-client")
+	_ = os.Setenv("AZURE_CLIENT_SECRET", "test-secret")
+	_ = os.Setenv("AZURE_SUBSCRIPTION_ID", "test-subscription")
+	defer func() {
+		_ = os.Unsetenv("AZURE_TENANT_ID")
+		_ = os.Unsetenv("AZURE_CLIENT_ID")
+		_ = os.Unsetenv("AZURE_CLIENT_SECRET")
+		_ = os.Unsetenv("AZURE_SUBSCRIPTION_ID")
+	}()
+
+	cfg := createTestConfig("readonly", map[string]bool{})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		service := NewService(cfg)
+		err := service.Initialize()
+		if err != nil {
+			b.Fatalf("Initialize failed: %v", err)
+		}
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -149,17 +149,21 @@ func TestService(t *testing.T) {
 			// Create service
 			service := NewService(cfg)
 
+			// Verify service was created properly
+			if service == nil { //nolint:staticcheck // False positive: t.Fatal prevents nil dereference
+				t.Fatal("Service should not be nil")
+			}
+
 			// Initialize service (this will register all tools)
-			err := service.Initialize()
-			if err != nil {
+			if err := service.Initialize(); err != nil {
 				t.Fatalf("Failed to initialize service: %v", err)
 			}
 
 			// Verify initialization completed
-			if service.azClient == nil {
+			if service.azClient == nil { //nolint:staticcheck // False positive: service verified non-nil above
 				t.Error("Azure client should be initialized")
 			}
-			if service.mcpServer == nil {
+			if service.mcpServer == nil { //nolint:staticcheck // False positive: service verified non-nil above
 				t.Error("MCP server should be initialized")
 			}
 
@@ -269,25 +273,27 @@ func TestServiceInitialization(t *testing.T) {
 	cfg := createTestConfig("readonly", map[string]bool{})
 	service := NewService(cfg)
 
-	// Test service creation and configuration in one block
-	if service == nil {
+	// Test service creation - must be non-nil
+	if service == nil { //nolint:staticcheck // False positive: t.Fatal prevents nil dereference
 		t.Fatal("Service should not be nil")
 	}
-	if service.cfg != cfg {
+
+	// Test configuration is set correctly
+	if service.cfg != cfg { //nolint:staticcheck // False positive: service verified non-nil above
 		t.Error("Service config should match provided config")
 	}
 
 	// Test initialization
-	err := service.Initialize()
-	if err != nil {
+	if err := service.Initialize(); err != nil {
 		t.Fatalf("Initialize should not return error: %v", err)
 	}
 
-	// Test that infrastructure is initialized - check both together
-	if service.azClient == nil || service.mcpServer == nil {
-		t.Errorf("Service infrastructure not properly initialized: azClient=%v, mcpServer=%v",
-			service.azClient != nil, service.mcpServer != nil)
-		return
+	// Test that infrastructure is initialized
+	if service.azClient == nil { //nolint:staticcheck // False positive: service verified non-nil above
+		t.Error("Azure client should be initialized after Initialize()")
+	}
+	if service.mcpServer == nil { //nolint:staticcheck // False positive: service verified non-nil above
+		t.Error("MCP server should be initialized after Initialize()")
 	}
 
 	t.Logf("Service initialized successfully")


### PR DESCRIPTION
make a clear method hierarchy
```
Initialize()
├── initializeInfrastructure()
└── registerAllComponents()
    ├── registerAzureComponents()
    │   ├── registerAksOpsComponent()
    │   ├── registerMonitoringComponent()
    │   ├── registerFleetComponent()
    │   ├── registerNetworkComponent()
    │   ├── registerComputeComponent()
    │   ├── registerDetectorComponent()
    │   ├── registerAdvisorComponent()
    │   └── registerInspektorGadgetComponent()
    └── registerKubernetesComponents()
        ├── registerKubectlComponent()
        └── registerOptionalKubernetesComponents()
            ├── registerHelmComponent()
            └── registerCiliumComponent()
```