### PR TITLE
chore: Include kubectl/helm in the image

### DIFF
--- a/cmd/aks-mcp/container_test.go
+++ b/cmd/aks-mcp/container_test.go
@@ -192,7 +192,7 @@ func TestDockerfileConfiguration(t *testing.T) {
 	content := string(dockerfile)
 
 	// Validate Azure CLI installation
-	if !strings.Contains(content, "pip3 install --break-system-packages azure-cli") {
+	if !strings.Contains(content, "pip3 install --break-system-packages --no-cache-dir azure-cli") {
 		t.Error("Dockerfile missing Azure CLI installation")
 	}
 


### PR DESCRIPTION
This change includes kubectl/helm in the image, mainly needed as dependency for https://github.com/mqasimsarfraz/mcp-registry/commit/4be76f651c481127b2289474ba490031d08fab26. Once I merged, I will go test and open the upstream PR in docker mcp registy.