### PR TITLE
update readme to workaround mcp server starting at WLS environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,21 @@ Once started, the MCP server will appear in the **Copilot Chat: Configure Tools*
 
 Try a prompt like *"List all my AKS clusters"*, which will start using tools from the AKS-MCP server.
 
+Note:
+For VS Code that is runing inside of WLS environment, starting AKS MCP server could fail with error "Connection state: Error spawn /home/path/.vs-kubernetes/tools/aks-mcp/v0.0.3/aks-mcp ENOENT", it means VS code cannot find this file. The resolution is modifying the mcp.json file as following to make it running with wls.
+
+```json
+"AKS MCP": {
+			"command": "wsl",
+			"args": [
+				"<aks-mcp path>",
+				"--transport",
+				"stdio"
+			]
+}
+```
+
+
 > **💡 Benefits**: The AKS extension handles binary downloads, updates, and configuration automatically, ensuring you always have the latest version with optimal settings.
 
 ### Alternative Installation Methods


### PR DESCRIPTION
Starting the aks mcp server at WLS wont work for me, after did investigation and found we need to run it with "wls" command. updated this Readme to unblock others.

2025-08-05 16:39:55.397 [info] Connection state: Starting
2025-08-05 16:39:55.400 [info] Connection state: Error spawn /home/qizhe/.vs-kubernetes/tools/aks-mcp/v0.0.3/aks-mcp ENOENT
2025-08-05 16:42:21.294 [info] Stopping server AKS MCP
2025-08-05 16:44:57.845 [info] Stopping server AKS MCP
2025-08-05 16:44:57.870 [info] Starting server AKS MCP
2025-08-05 16:44:57.873 [info] Connection state: Starting
2025-08-05 16:44:57.895 [info] Starting server from LocalProcess extension host
2025-08-05 16:44:57.901 [info] Connection state: Starting
2025-08-05 16:44:57.909 [info] Connection state: Running
2025-08-05 16:44:58.680 [warning] [server stderr] 2025/08/05 16:44:58 Azure client initialized successfully