### PR TITLE
fix: update log messages and comments to use AKS MCP naming

### DIFF
--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 )
 
-// Validator handles all validation logic for MCP Kubernetes
+// Validator handles all validation logic for AKS MCP
 type Validator struct {
 	// Configuration to validate
 	config *ConfigData

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,14 +25,14 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-// Service represents the MCP Kubernetes service
+// Service represents the AKS MCP service
 type Service struct {
 	cfg       *config.ConfigData
 	mcpServer *server.MCPServer
 	azClient  *azureclient.AzureClient
 }
 
-// NewService creates a new MCP Kubernetes service
+// NewService creates a new AKS MCP service
 func NewService(cfg *config.ConfigData) *Service {
 	return &Service{
 		cfg: cfg,
@@ -89,12 +89,12 @@ func (s *Service) registerAllComponents() {
 
 // Run starts the service with the specified transport
 func (s *Service) Run() error {
-	log.Println("MCP Kubernetes version:", version.GetVersion())
+	log.Println("AKS MCP version:", version.GetVersion())
 
 	// Start the server
 	switch s.cfg.Transport {
 	case "stdio":
-		log.Println("MCP Kubernetes version:", version.GetVersion())
+		log.Println("AKS MCP version:", version.GetVersion())
 		log.Println("Listening for requests on STDIO...")
 		return server.ServeStdio(s.mcpServer)
 	case "sse":


### PR DESCRIPTION
Changed references from "MCP Kubernetes" to "AKS MCP" in log messages and comments to maintain consistent naming throughout the codebase.