### PR TITLE
Fix: filter control plane logs by categories when using  AKSControlPlane table

### DIFF
--- a/internal/components/monitor/diagnostics/kql.go
+++ b/internal/components/monitor/diagnostics/kql.go
@@ -166,7 +166,12 @@ func getSupportedResourceSpecificCategories() []string {
 func (q *KQLQueryBuilder) buildBaseQuery() (string, error) {
 	switch q.tableMode {
 	case ResourceSpecificMode:
-		return fmt.Sprintf("%s | where _ResourceId == '%s'", q.selectedTable, q.processedResourceID), nil
+		baseQuery := fmt.Sprintf("%s | where _ResourceId == '%s'", q.selectedTable, q.processedResourceID)
+		// For AKSControlPlane table, we need to filter by Category since multiple log categories use the same table
+		if q.selectedTable == "AKSControlPlane" {
+			baseQuery += fmt.Sprintf(" | where Category == '%s'", q.category)
+		}
+		return baseQuery, nil
 	case AzureDiagnosticsMode:
 		return fmt.Sprintf("%s | where Category == '%s' and ResourceId == '%s'", q.selectedTable, q.category, q.processedResourceID), nil
 	default:


### PR DESCRIPTION
When the diagnostics setting is using the dedicated table, there are some logs (kube-*, guard, etc) except kube-audit-* share the same table AKSControlPlane.  The bug is it doesn't filter logs by categories so all logs will be returned to agent. 
This PR is to fix the problem.