### PR TITLE
chore/inspektor_gadget: Add upgrade action

### DIFF
--- a/docs/inspektor-gadget-usage.md
+++ b/docs/inspektor-gadget-usage.md
@@ -67,7 +67,7 @@ Can you observe system calls for the pod my-pod in the default namespace for few
 
 ## Prerequisites
 
-- A kubeconfig file that has access to the AKS cluster. You will need to restart the MCP server if you change the kubeconfig file.
+- A kubeconfig file that has access to the AKS cluster.
 - The tool requires Inspektor Gadget to be installed in the cluster. If you are running with `--access-level=readwrite` or more, the MCP server will automatically
   install Inspektor Gadget (action `deploy` ) in the cluster otherwise you can follow the steps to install it manually: [Inspektor Gadget Installation](https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/logs/capture-system-insights-from-aks#how-to-install-inspektor-gadget-in-an-aks-cluster) or
   use the official Helm chart: [Inspektor Gadget Helm Chart](https://inspektor-gadget.io/docs/latest/reference/install-kubernetes#installation-with-the-helm-chart):

--- a/internal/components/inspektorgadget/const.go
+++ b/internal/components/inspektorgadget/const.go
@@ -6,6 +6,8 @@ const (
 	deployAction = "deploy"
 	// undeployAction is the action to remove Inspektor Gadget from the cluster
 	undeployAction = "undeploy"
+	// upgradeAction is the action to upgrade Inspektor Gadget in the cluster
+	upgradeAction = "upgrade"
 	// isDeployedAction is the action to check if Inspektor Gadget is deployed
 	isDeployedAction = "is_deployed"
 )

--- a/internal/components/inspektorgadget/gadgets.go
+++ b/internal/components/inspektorgadget/gadgets.go
@@ -19,10 +19,14 @@ type Gadget struct {
 	ParamsFunc func(filterParams map[string]interface{}, gadgetParams map[string]string)
 }
 
+func (g *Gadget) getImage(version string) string {
+	return fmt.Sprintf("%s:%s", g.Image, gadgetVersionFor(version))
+}
+
 var gadgets = []Gadget{
 	{
 		Name:        observeDNS,
-		Image:       "ghcr.io/inspektor-gadget/gadget/trace_dns:latest",
+		Image:       "ghcr.io/inspektor-gadget/gadget/trace_dns",
 		Description: "Observes DNS queries in the cluster",
 		Params: map[string]interface{}{
 			"name": map[string]interface{}{
@@ -75,7 +79,7 @@ var gadgets = []Gadget{
 	},
 	{
 		Name:        observeTCP,
-		Image:       "ghcr.io/inspektor-gadget/gadget/trace_tcp:latest",
+		Image:       "ghcr.io/inspektor-gadget/gadget/trace_tcp",
 		Description: "Observes TCP traffic in the cluster",
 		Params: map[string]interface{}{
 			"source_port": map[string]interface{}{
@@ -121,7 +125,7 @@ var gadgets = []Gadget{
 	},
 	{
 		Name:        observeFileOpen,
-		Image:       "ghcr.io/inspektor-gadget/gadget/trace_open:latest",
+		Image:       "ghcr.io/inspektor-gadget/gadget/trace_open",
 		Description: "Observes file open operations in the cluster",
 		Params: map[string]interface{}{
 			"path": map[string]interface{}{
@@ -152,7 +156,7 @@ var gadgets = []Gadget{
 	},
 	{
 		Name:        observeProcessExecution,
-		Image:       "ghcr.io/inspektor-gadget/gadget/trace_exec:latest",
+		Image:       "ghcr.io/inspektor-gadget/gadget/trace_exec",
 		Description: "Observes process execution in the cluster",
 		Params: map[string]interface{}{
 			"command": map[string]interface{}{
@@ -172,7 +176,7 @@ var gadgets = []Gadget{
 	},
 	{
 		Name:        observeSignal,
-		Image:       "ghcr.io/inspektor-gadget/gadget/trace_signal:latest",
+		Image:       "ghcr.io/inspektor-gadget/gadget/trace_signal",
 		Description: "Traces signals sent to containers in the cluster",
 		Params: map[string]interface{}{
 			"signal": map[string]interface{}{
@@ -193,7 +197,7 @@ var gadgets = []Gadget{
 	},
 	{
 		Name:        observeSystemCalls,
-		Image:       "ghcr.io/inspektor-gadget/gadget/traceloop:latest",
+		Image:       "ghcr.io/inspektor-gadget/gadget/traceloop",
 		Description: "Observes system calls in the cluster",
 		Params: map[string]interface{}{
 			"syscall": map[string]interface{}{
@@ -215,7 +219,7 @@ var gadgets = []Gadget{
 	},
 	{
 		Name:        topFile,
-		Image:       "ghcr.io/inspektor-gadget/gadget/top_file:latest",
+		Image:       "ghcr.io/inspektor-gadget/gadget/top_file",
 		Description: "Shows top files by read/write operations",
 		Params: map[string]interface{}{
 			"max_entries": map[string]interface{}{
@@ -240,7 +244,7 @@ var gadgets = []Gadget{
 	},
 	{
 		Name:        topTCP,
-		Image:       "ghcr.io/inspektor-gadget/gadget/top_tcp:latest",
+		Image:       "ghcr.io/inspektor-gadget/gadget/top_tcp",
 		Description: "Shows top TCP connections by traffic volume",
 		Params: map[string]interface{}{
 			"max_entries": map[string]interface{}{

--- a/internal/components/inspektorgadget/gadgets_test.go
+++ b/internal/components/inspektorgadget/gadgets_test.go
@@ -1,6 +1,9 @@
 package inspektorgadget
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestGadgets(t *testing.T) {
 	for _, gadget := range gadgets {
@@ -9,6 +12,9 @@ func TestGadgets(t *testing.T) {
 		}
 		if gadget.Image == "" {
 			t.Errorf("Gadget image is empty for %s", gadget.Name)
+		}
+		if gadget.Image != "" && strings.Contains(gadget.Image, ":") {
+			t.Errorf("Gadget image %s should not contain a version tag", gadget.Image)
 		}
 		if gadget.Description == "" {
 			t.Errorf("Gadget description is empty for %s", gadget.Name)

--- a/internal/components/inspektorgadget/handlers.go
+++ b/internal/components/inspektorgadget/handlers.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Azure/aks-mcp/internal/command"
@@ -76,8 +78,8 @@ func InspektorGadgetHandler(mgr GadgetManager, cfg *config.ConfigData) tools.Res
 			return handleGetResultsAction(ctx, mgr, actionParams, cfg)
 		case listGadgetsAction:
 			return handleListGadgetsAction(ctx, mgr, cfg)
-		case isDeployedAction, undeployAction, deployAction:
-			return handleLifecycleAction(deployed, action, actionParams, cfg)
+		case isDeployedAction, undeployAction, upgradeAction, deployAction:
+			return handleLifecycleAction(mgr, deployed, action, actionParams, cfg)
 		}
 
 		return "", fmt.Errorf("unsupported action: %s", action)
@@ -112,7 +114,11 @@ func handleRunAction(ctx context.Context, mgr GadgetManager, actionParams map[st
 	dur := time.Duration(duration) * time.Second
 	gadgetParams[paramFetchInterval] = (dur / 2).String()
 
-	resp, err := mgr.RunGadget(ctx, gadget.Image, gadgetParams, dur)
+	ver, err := mgr.GetVersion()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get inspektor gadget version: %v\n", err)
+	}
+	resp, err := mgr.RunGadget(ctx, gadget.getImage(ver), gadgetParams, dur)
 	if err != nil {
 		return "", fmt.Errorf("running gadget: %w", err)
 	}
@@ -151,7 +157,12 @@ func handleStartAction(ctx context.Context, mgr GadgetManager, actionParams map[
 		"filterParams=" + filterParamsStr,
 		"namespaces=" + getNamespace(gadgetParams),
 	}
-	id, err := mgr.StartGadget(ctx, gadget.Image, gadgetParams, tags)
+
+	ver, err := mgr.GetVersion()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get inspektor gadget version: %v\n", err)
+	}
+	id, err := mgr.StartGadget(ctx, gadget.getImage(ver), gadgetParams, tags)
 	if err != nil {
 		return "", fmt.Errorf("starting gadget: %w", err)
 	}
@@ -219,7 +230,7 @@ func handleListGadgetsAction(ctx context.Context, mgr GadgetManager, cfg *config
 	return string(JSONData), nil
 }
 
-func handleLifecycleAction(deployed bool, action string, actionParams map[string]interface{}, cfg *config.ConfigData) (string, error) {
+func handleLifecycleAction(mgr GadgetManager, deployed bool, action string, actionParams map[string]interface{}, cfg *config.ConfigData) (string, error) {
 	// TODO: use security.Validator once helm readwrite/admin operations are implemented
 	if !cfg.SecurityConfig.IsNamespaceAllowed(inspektorGadgetChartNamespace) {
 		return "", fmt.Errorf("namespace %s is not allowed by security policy", inspektorGadgetChartNamespace)
@@ -231,10 +242,19 @@ func handleLifecycleAction(deployed bool, action string, actionParams map[string
 		return "", fmt.Errorf("action %q requires 'readwrite' or 'admin' access level, current access level is '%s'", action, cfg.AccessLevel)
 	}
 
+	installedVersion, err := mgr.GetVersion()
+	if err != nil && deployed {
+		return "", fmt.Errorf("getting installed version: %w", err)
+	}
+	latestVersion, err := getLatestVersionFromGitHub()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get latest version: %v\n", err)
+	}
+
 	switch action {
 	case isDeployedAction:
 		if deployed {
-			return "inspektor gadget is deployed", nil
+			return "inspektor gadget is deployed (version: " + installedVersion + ", latest: " + latestVersion + ")", nil
 		}
 		return "inspektor gadget is not deployed", nil
 	case undeployAction:
@@ -244,9 +264,17 @@ func handleLifecycleAction(deployed bool, action string, actionParams map[string
 		return handleUndeployAction(cfg)
 	case deployAction:
 		if deployed {
-			return "inspektor gadget is already deployed", nil
+			return "inspektor gadget is already deployed (version: " + installedVersion + ", latest: " + latestVersion + ")", nil
 		}
 		return handleDeployAction(actionParams, cfg)
+	case upgradeAction:
+		if !deployed {
+			return "inspektor gadget is not deployed, no upgrade needed", nil
+		}
+		if installedVersion == latestVersion {
+			return fmt.Sprintf("inspektor gadget is already at the latest version (%s), no upgrade needed", installedVersion), nil
+		}
+		return handleUpgradeAction(actionParams, cfg)
 	}
 
 	return "", fmt.Errorf("unsupported lifecycle action %q, must be one of %v", action, getLifecycleActions())
@@ -266,6 +294,28 @@ func handleDeployAction(actionParams map[string]interface{}, cfg *config.ConfigD
 func handleUndeployAction(cfg *config.ConfigData) (string, error) {
 	helmArgs := fmt.Sprintf("uninstall %s -n %s", inspektorGadgetChartRelease, inspektorGadgetChartNamespace)
 	process := command.NewShellProcess("helm", cfg.Timeout)
+	return process.Run(helmArgs)
+}
+
+func handleUpgradeAction(actionParams map[string]interface{}, cfg *config.ConfigData) (string, error) {
+	// Check if the release exists before upgrading
+	helmGetArgs := fmt.Sprintf("get metadata %s -n %s", inspektorGadgetChartRelease, inspektorGadgetChartNamespace)
+	process := command.NewShellProcess("helm", cfg.Timeout)
+	out, err := process.Run(helmGetArgs)
+	if err != nil {
+		return "", fmt.Errorf("getting helm release %s: %w", inspektorGadgetChartRelease, err)
+	}
+	if strings.Contains(out, "release: not found") {
+		return "", fmt.Errorf("helm release not found, cannot upgrade. Did you manually deploy Inspektor Gadget")
+	}
+	// Proceed with upgrade if the release exists
+	chartVersion, ok := actionParams["chart_version"].(string)
+	if !ok || chartVersion == "" {
+		chartVersion = getChartVersion()
+	}
+	chartUrl := fmt.Sprintf("%s:%s", inspektorGadgetChartURL, chartVersion)
+	helmArgs := fmt.Sprintf("upgrade %s -n %s --create-namespace %s", inspektorGadgetChartRelease, inspektorGadgetChartNamespace, chartUrl)
+	process = command.NewShellProcess("helm", cfg.Timeout)
 	return process.Run(helmArgs)
 }
 

--- a/internal/components/inspektorgadget/handlers.go
+++ b/internal/components/inspektorgadget/handlers.go
@@ -306,7 +306,7 @@ func handleUpgradeAction(actionParams map[string]interface{}, cfg *config.Config
 		return "", fmt.Errorf("getting helm release %s: %w", inspektorGadgetChartRelease, err)
 	}
 	if strings.Contains(out, "release: not found") {
-		return "", fmt.Errorf("helm release not found, cannot upgrade. Did you manually deploy Inspektor Gadget")
+		return "", fmt.Errorf("helm release not found, cannot upgrade. Did you manually deploy Inspektor Gadget?")
 	}
 	// Proceed with upgrade if the release exists
 	chartVersion, ok := actionParams["chart_version"].(string)

--- a/internal/components/inspektorgadget/handlers_test.go
+++ b/internal/components/inspektorgadget/handlers_test.go
@@ -13,6 +13,7 @@ import (
 // mockGadgetManager implements GadgetManager interface for testing
 type mockGadgetManager struct {
 	isDeployed      bool
+	version         string
 	deployedMessage string
 	deployError     error
 	runResult       string
@@ -62,8 +63,8 @@ func (m *mockGadgetManager) IsDeployed(ctx context.Context) (bool, string, error
 	return m.isDeployed, m.deployedMessage, m.deployError
 }
 
-func (m *mockGadgetManager) Close() error {
-	return nil
+func (m *mockGadgetManager) GetVersion() (string, error) {
+	return m.version, nil
 }
 
 func TestInspektorGadgetHandler(t *testing.T) {

--- a/internal/components/inspektorgadget/helpers.go
+++ b/internal/components/inspektorgadget/helpers.go
@@ -5,19 +5,37 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"runtime/debug"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 )
 
+var (
+	gadgetVersionRegex  = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	githubVersionOnce   sync.Once
+	cachedGithubVersion string
+	githubVersionError  error
+)
+
+// gadgetVersionFor maps the Inspektor Gadget version to a corresponding gadget version.
+// Returns the stable version if installed; otherwise, returns "latest".
+func gadgetVersionFor(igVersion string) string {
+	if gadgetVersionRegex.MatchString(igVersion) {
+		return "v" + igVersion
+	}
+	return "latest"
+}
+
 // getChartVersion retrieves the version of the Inspektor Gadget Helm chart.
 // It first attempts to get the version from GitHub releases, and if that fails,
 // it falls back to the version from the build information.
 func getChartVersion() string {
-	if version, err := getChartVersionFromGitHub(); err == nil {
+	if version, err := getLatestVersionFromGitHub(); err == nil {
 		return version
 	}
 	return getChartVersionFromBuild()
@@ -37,30 +55,36 @@ func getChartVersionFromBuild() string {
 	return "1.0.0-dev"
 }
 
-// getChartVersionFromGitHub retrieves the version of the Inspektor Gadget Helm chart from the GitHub repository.
-func getChartVersionFromGitHub() (string, error) {
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(inspektorGadgetReleaseURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to get latest release: %w", err)
-	}
-	defer func() {
-		if err = resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "closing response body: %v\n", err)
+// getLatestVersionFromGitHub retrieves the version of the latest Inspektor Gadget release from GitHub.
+func getLatestVersionFromGitHub() (string, error) {
+	githubVersionOnce.Do(func() {
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get(inspektorGadgetReleaseURL)
+		if err != nil {
+			githubVersionError = fmt.Errorf("failed to get latest release: %w", err)
+			return
 		}
-	}()
+		defer func() {
+			if err = resp.Body.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "closing response body: %v\n", err)
+			}
+		}()
 
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to get latest release, status code: %d", resp.StatusCode)
-	}
+		if resp.StatusCode != http.StatusOK {
+			githubVersionError = fmt.Errorf("failed to get latest release, status code: %d", resp.StatusCode)
+			return
+		}
 
-	var release struct {
-		TagName string `json:"tag_name"`
-	}
-	if err = json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", fmt.Errorf("decoding latest release response: %w", err)
-	}
-	return strings.TrimPrefix(release.TagName, "v"), nil
+		var release struct {
+			TagName string `json:"tag_name"`
+		}
+		if err = json.NewDecoder(resp.Body).Decode(&release); err != nil {
+			githubVersionError = fmt.Errorf("decoding latest release response: %w", err)
+			return
+		}
+		cachedGithubVersion = strings.TrimPrefix(release.TagName, "v")
+	})
+	return cachedGithubVersion, githubVersionError
 }
 
 // gadgetInstanceFromAPI converts an API GadgetInstance to a GadgetInstance struct.
@@ -122,12 +146,12 @@ func gadgetInstanceFromAPI(instance *api.GadgetInstance) *GadgetInstance {
 
 // isValidLifecycleAction checks if the provided action is a valid lifecycle action for Inspektor Gadget.
 func isValidLifecycleAction(action string) bool {
-	return action == deployAction || action == undeployAction || action == isDeployedAction
+	return action == deployAction || action == undeployAction || action == isDeployedAction || action == upgradeAction
 }
 
 // getLifecycleActions returns all valid lifecycle actions for Inspektor Gadget.
 func getLifecycleActions() []string {
-	return []string{deployAction, undeployAction, isDeployedAction}
+	return []string{deployAction, undeployAction, upgradeAction, isDeployedAction}
 }
 
 // getReadonlyLifecycleActions returns all valid readonly lifecycle actions for Inspektor Gadget.

--- a/internal/components/inspektorgadget/helpers_test.go
+++ b/internal/components/inspektorgadget/helpers_test.go
@@ -1,0 +1,26 @@
+package inspektorgadget
+
+import "testing"
+
+func TestGadgetVersionForIGVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected string
+	}{
+		{"Valid version", "0.42.0", "v0.42.0"},
+		{"Invalid version", "invalid", "latest"},
+		{"Empty version", "", "latest"},
+		{"Canonical version", "1.2.3+build", "latest"},
+		{"Semver with pre-release", "1.2.3-alpha", "latest"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gadgetVersionFor(tt.version)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/internal/components/inspektorgadget/registry.go
+++ b/internal/components/inspektorgadget/registry.go
@@ -21,6 +21,7 @@ func RegisterInspektorGadgetTool() mcp.Tool {
 				listGadgetsAction+" to list all running gadgets"+
 				deployAction+" to deploy Inspektor Gadget, "+
 				undeployAction+" to undeploy Inspektor Gadget"+
+				upgradeAction+" to upgrade Inspektor Gadget, "+
 				isDeployedAction+" to check if Inspektor Gadget is deployed",
 			),
 			mcp.Enum(getActions()...),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -196,11 +196,7 @@ func (s *Service) registerOptionalKubernetesComponents() {
 
 // registerInspektorGadgetComponent registers Inspektor Gadget tools for observability
 func (s *Service) registerInspektorGadgetComponent() {
-	gadgetMgr, err := inspektorgadget.NewGadgetManager()
-	if err != nil {
-		log.Printf("Warning: Failed to create gadget manager: %v", err)
-		return
-	}
+	gadgetMgr := inspektorgadget.NewGadgetManager()
 
 	// Register Inspektor Gadget tool
 	log.Println("Registering Inspektor Gadget Observability tool: inspektor_gadget_observability")


### PR DESCRIPTION
This PR makes changes to handle "Day 2" of `inspektor_gadget_observability` tool. It adds upgrade action to allow users to upgrade Inspektor Gadget. Also, includes this version information in the `is_deployed` to hint for an upgrade. 

Other improvements include aligning gadget version with Inspektor Gadget version to ensure compatibility. Also, runtime now always uses the latest `kubeconfig` to ensure if user does `get-credentials` they don't need to restart the server and introducing lock formatter which we need as part of [new IG release](https://github.com/inspektor-gadget/inspektor-gadget/pull/4707). 

## Testing Done

I have included some tests. Also, [asked copilot to do some testing.](https://gist.githubusercontent.com/mqasimsarfraz/da0a4b8c25337a4e257db89f9588a130/raw/bc3667224b61245712c962627dbdf9b4ab427728/copilot.log) 