### PR TITLE
Fix: validate all cli

### DIFF
--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -37,6 +37,24 @@ func (v *Validator) validateCli() bool {
 		valid = false
 	}
 
+	// kubectl is always required (core Kubernetes functionality)
+	if !v.isCliInstalled("kubectl") {
+		v.errors = append(v.errors, "kubectl is not installed or not found in PATH")
+		valid = false
+	}
+
+	// helm is required for Inspektor Gadget component and when explicitly enabled
+	if !v.isCliInstalled("helm") {
+		v.errors = append(v.errors, "helm is not installed or not found in PATH (required for Inspektor Gadget observability)")
+		valid = false
+	}
+
+	// cilium is optional - only validate if explicitly enabled
+	if v.config.AdditionalTools["cilium"] && !v.isCliInstalled("cilium") {
+		v.errors = append(v.errors, "cilium is not installed or not found in PATH (required when --additional-tools includes cilium)")
+		valid = false
+	}
+
 	return valid
 }
 


### PR DESCRIPTION
The validator is missing several CLI tool validations. Here are the CLI tools being used by the system:

az - Already validated ✅
kubectl - Always required (core Kubernetes functionality) ❌ Missing validation
helm - Used by Inspektor Gadget component and optional additional tools ❌ Missing validation
cilium - Optional tool (when enabled via --additional-tools) ❌ Missing validation

This PR is to add validation for them.