### PR TITLE
fix: add missing telemetry for k8s tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2 v2.2.1
-	github.com/Azure/mcp-kubernetes v0.0.7
+	github.com/Azure/mcp-kubernetes v0.0.8
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/inspektor-gadget/inspektor-gadget v0.43.0
 	github.com/mark3labs/mcp-go v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/Azure/mcp-kubernetes v0.0.7 h1:NU/MKUL9GDH0OJDwnsQtjyNYmClmjLRehn/vGsjCjA4=
-github.com/Azure/mcp-kubernetes v0.0.7/go.mod h1:qDusmS5NdOyEDCWJZNvIXciwzpLRTmul7tOpRkQGMUs=
+github.com/Azure/mcp-kubernetes v0.0.8 h1:I12xT+EV0epjPR2CbXWIsYFjgAH9xeUUt2mKT5E6FnA=
+github.com/Azure/mcp-kubernetes v0.0.8/go.mod h1:H+UCYBw8V3dJGRwB+l+0doPuI/r6n8o1Wlj1kwI++wk=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=

--- a/internal/k8s/adapter.go
+++ b/internal/k8s/adapter.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Azure/aks-mcp/internal/tools"
 	k8sconfig "github.com/Azure/mcp-kubernetes/pkg/config"
 	k8ssecurity "github.com/Azure/mcp-kubernetes/pkg/security"
+	k8stelemetry "github.com/Azure/mcp-kubernetes/pkg/telemetry"
 	k8stools "github.com/Azure/mcp-kubernetes/pkg/tools"
 )
 
@@ -19,14 +20,16 @@ func ConvertConfig(cfg *config.ConfigData) *k8sconfig.ConfigData {
 
 	// Create K8s config
 	k8sCfg := &k8sconfig.ConfigData{
-		AdditionalTools: cfg.AdditionalTools,
-		Timeout:         cfg.Timeout,
-		SecurityConfig:  k8sSecurityConfig,
-		Transport:       cfg.Transport,
-		Host:            cfg.Host,
-		Port:            cfg.Port,
-		AccessLevel:     cfg.AccessLevel,
-		AllowNamespaces: cfg.AllowNamespaces,
+		AdditionalTools:  cfg.AdditionalTools,
+		Timeout:          cfg.Timeout,
+		SecurityConfig:   k8sSecurityConfig,
+		Transport:        cfg.Transport,
+		Host:             cfg.Host,
+		Port:             cfg.Port,
+		AccessLevel:      cfg.AccessLevel,
+		AllowNamespaces:  cfg.AllowNamespaces,
+		OTLPEndpoint:     cfg.OTLPEndpoint,
+		TelemetryService: k8stelemetry.TelemetryInterface(cfg.TelemetryService),
 	}
 
 	return k8sCfg


### PR DESCRIPTION
- Upgrade github.com/Azure/mcp-kubernetes from v0.0.7 to v0.0.8
- Add telemetry configuration fields to K8s adapter
- Pass through OTLP endpoint and telemetry service to K8s config