### PR TITLE
feat: add prompt query_aks_cluster_metadata_from_kubeconfig

### DIFF
--- a/internal/prompts/cluster.go
+++ b/internal/prompts/cluster.go
@@ -1,0 +1,65 @@
+package prompts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/aks-mcp/internal/config"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// RegisterQueryAKSMetadataFromKubeconfigPrompt registers the prompts to query aks cluster from active kubeconfig.
+func RegisterQueryAKSMetadataFromKubeconfigPrompt(s *server.MCPServer, cfg *config.ConfigData) {
+	s.AddPrompt(mcp.NewPrompt("query_aks_cluster_metadata_from_kubeconfig",
+		mcp.WithPromptDescription("Query AKS cluster (subscriptionID, resourceGroup and name) from current kubeconfig"),
+	), func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+
+		promptContent := fmt.Sprintf(`# Query AKS cluster metadata from current kubeconfig
+
+This guide will help you query AKS cluster metadata (subscriptionID, resourceGroup and name) from current kubeconfig.
+
+## Steps
+
+### 1. Retrieve the control plane FQDN:
+
+Invoke the kubectl_cluster MCP tool with inputs:
+	{
+		"operation": "cluster-info",
+		"resource": "",
+		"args": ""
+	}
+
+
+This will show the Kubernetes control plane endpoint URL (FQDN).
+
+### 2. List available AKS clusters in your subscription
+
+Invoke the az_aks_operations MCP tool with inputs:
+	{
+		"operation": "list",
+		"args": "--query "[].{id:id, fqdn:fqdn}" -o json"
+	}
+
+This will show all the AKS clusters (in JSON format) in user pre-configured subscription.
+
+### 3. Find the AKS cluster matching FQDN
+
+Compare the control plane FQDN from Step 1 with the FQDNs of the AKS clusters from Step 2,
+figure out the matched AKS cluster, and then respond the AKS cluster's subscriptionID, resourceGroup and name.
+`)
+
+		return &mcp.GetPromptResult{
+			Description: "Query AKS cluster (subscriptionID, resourceGroup and name) from current kubeconfig",
+			Messages: []mcp.PromptMessage{
+				{
+					Role: mcp.RoleAssistant,
+					Content: mcp.TextContent{
+						Type: "text",
+						Text: promptContent,
+					},
+				},
+			},
+		}, nil
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/aks-mcp/internal/components/network"
 	"github.com/Azure/aks-mcp/internal/config"
 	"github.com/Azure/aks-mcp/internal/k8s"
+	"github.com/Azure/aks-mcp/internal/prompts"
 	"github.com/Azure/aks-mcp/internal/tools"
 	"github.com/Azure/aks-mcp/internal/version"
 	"github.com/Azure/mcp-kubernetes/pkg/cilium"
@@ -70,6 +71,7 @@ func (s *Service) initializeInfrastructure() error {
 		"AKS MCP",
 		version.GetVersion(),
 		server.WithResourceCapabilities(true, true),
+		server.WithPromptCapabilities(true),
 		server.WithLogging(),
 		server.WithRecovery(),
 	)
@@ -85,6 +87,17 @@ func (s *Service) registerAllComponents() {
 
 	// Kubernetes Components
 	s.registerKubernetesComponents()
+
+	// Prompts
+	s.registerPrompts()
+}
+
+// registerPrompts registers all available prompts
+func (s *Service) registerPrompts() {
+	log.Println("Registering Prompts...")
+
+	log.Println("Registering prompt: query_aks_cluster_metadata_from_kubeconfig")
+	prompts.RegisterQueryAKSMetadataFromKubeconfigPrompt(s.mcpServer, s.cfg)
 }
 
 // Run starts the service with the specified transport


### PR DESCRIPTION
Add a prompt to query AKS cluster metadata from the current kubeconfig. When using github copilot, a slash command would be added with name /mcp.aks-mcp.query_aks_cluster_metadata_from_kubeconfig.