### PR TITLE
makefile/docs: enforce bash for multi-line targets and document in README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # AKS-MCP Makefile
 # Provides convenience targets for development, building, testing, and releasing
 
+# Run multi-line recipes in bash and fail on any command error
+SHELL := /usr/bin/env bash
+SHELLFLAGS := -eo pipefail -c
+
 # Variables
 BINARY_NAME = aks-mcp
 MAIN_PATH = ./cmd/aks-mcp
@@ -183,6 +187,7 @@ version: ## Show version information
 
 .PHONY: info
 info: ## Show build information
+	@echo "Shell: $(SHELL) $(SHELLFLAGS)"
 	@echo "Binary Name: $(BINARY_NAME)"
 	@echo "Main Path: $(MAIN_PATH)"
 	@echo "Docker Image: $(DOCKER_IMAGE):$(DOCKER_TAG)"

--- a/README.md
+++ b/README.md
@@ -525,6 +525,15 @@ Usage of ./aks-mcp:
 
 ## Development
 
+### Prerequisites
+
+- **Go** ≥ `1.24.x` installed on your local machine
+- **Bash** available as `/usr/bin/env bash` (Makefile targets use multi-line recipes with fail-fast mode)
+- **GNU Make** `4.x` or later
+- **Docker** *(optional, for container builds and testing)*
+
+> **Note:** If your login shell is different (e.g., `zsh` on **macOS**), you do **not** need to change it — the Makefile sets variables to run all recipes in `bash` for consistent behavior across platforms.
+
 ### Building from Source
 
 This project includes a Makefile for convenient development, building, and testing. To see all available targets:


### PR DESCRIPTION
Hey guys, first off, I want to say I really appreciate the solution this project provides, and I definitely want to contribute to it further.

As a starting point, I’ve made a small but meaningful enhancement to improve local development reliability.

- **Updated Makefile to explicitly use bash with `-eo pipefail` for multi-line recipes**  
  - By default, GNU Make uses `/bin/sh`, which often lacks `pipefail`. This means in multi-line recipes (like the `release` loop), a failing command in a pipeline may not cause the recipe to fail, leading to silent errors.  
  - Our `PLATFORMS` list is static, but a local build can still fail (e.g., due to a changed third-party dependency). Setting `bash -eo pipefail` ensures each command in the loop fails fast, preventing partial or misleading build results.

Example:

```bash
.PHONY: release
release: clean ## Build for all platforms
	@echo "==> Building for all platforms..."
	@mkdir -p dist
	@for platform in $(PLATFORMS); do \
		GOOS=$$(echo $$platform | cut -d'/' -f1); \
		GOARCH=$$(echo $$platform | cut -d'/' -f2); \
		output_name=$(BINARY_NAME)-$$GOOS-$$GOARCH; \
		if [ "$$GOOS" = "windows" ]; then \
			output_name="$$output_name.exe"; \
		fi; \
		echo "Building for $$GOOS/$$GOARCH..."; \
		# bash -eo pipefail ensures a single platform build failure stops the loop
		CGO_ENABLED=$(CGO_ENABLED) GOOS=$$GOOS GOARCH=$$GOARCH \
			go build $(BUILD_FLAGS) $(LDFLAGS) -o dist/$$output_name $(MAIN_PATH); \
	done
```

- Update README to document development dependencies and note shell behavior
