### PR TITLE
Feat: Version System Improvements

### DIFF
--- a/.slsa-goreleaser/darwin-amd64.yml
+++ b/.slsa-goreleaser/darwin-amd64.yml
@@ -20,6 +20,13 @@ flags:
   - -trimpath
   - -tags=withoutebpf # need by inspektor-gadget
 
+# (Optional) ldflags for version injection
+ldflags:
+  - "-X github.com/Azure/aks-mcp/internal/version.GitVersion={{ .Env.VERSION }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitCommit={{ .Env.COMMIT }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitTreeState={{ .Env.TREE_STATE }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.BuildMetadata={{ .Env.COMMIT_DATE }}"
+
 
 # (Optional) Working directory. (default: root of the project)
 # dir: ./relative/path/to/dir

--- a/.slsa-goreleaser/darwin-arm64.yml
+++ b/.slsa-goreleaser/darwin-arm64.yml
@@ -20,6 +20,13 @@ flags:
   - -trimpath
   - -tags=withoutebpf # need by inspektor-gadget
 
+# (Optional) ldflags for version injection
+ldflags:
+  - "-X github.com/Azure/aks-mcp/internal/version.GitVersion={{ .Env.VERSION }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitCommit={{ .Env.COMMIT }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitTreeState={{ .Env.TREE_STATE }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.BuildMetadata={{ .Env.COMMIT_DATE }}"
+
 # (Optional) Working directory. (default: root of the project)
 # dir: ./relative/path/to/dir
 

--- a/.slsa-goreleaser/linux-amd64.yml
+++ b/.slsa-goreleaser/linux-amd64.yml
@@ -20,6 +20,13 @@ flags:
   - -trimpath
   - -tags=withoutebpf # need by inspektor-gadget
 
+# (Optional) ldflags for version injection
+ldflags:
+  - "-X github.com/Azure/aks-mcp/internal/version.GitVersion={{ .Env.VERSION }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitCommit={{ .Env.COMMIT }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitTreeState={{ .Env.TREE_STATE }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.BuildMetadata={{ .Env.COMMIT_DATE }}"
+
 # (Optional) Working directory. (default: root of the project)
 # dir: ./relative/path/to/dir
 

--- a/.slsa-goreleaser/linux-arm64.yml
+++ b/.slsa-goreleaser/linux-arm64.yml
@@ -20,6 +20,13 @@ flags:
   - -trimpath
   - -tags=withoutebpf # need by inspektor-gadget
 
+# (Optional) ldflags for version injection
+ldflags:
+  - "-X github.com/Azure/aks-mcp/internal/version.GitVersion={{ .Env.VERSION }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitCommit={{ .Env.COMMIT }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitTreeState={{ .Env.TREE_STATE }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.BuildMetadata={{ .Env.COMMIT_DATE }}"
+
 # (Optional) Working directory. (default: root of the project)
 # dir: ./relative/path/to/dir
 

--- a/.slsa-goreleaser/windows-amd64.yml
+++ b/.slsa-goreleaser/windows-amd64.yml
@@ -19,6 +19,13 @@ flags:
   - -trimpath
   - -tags=withoutebpf # need by inspektor-gadget
 
+# (Optional) ldflags for version injection
+ldflags:
+  - "-X github.com/Azure/aks-mcp/internal/version.GitVersion={{ .Env.VERSION }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitCommit={{ .Env.COMMIT }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitTreeState={{ .Env.TREE_STATE }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.BuildMetadata={{ .Env.COMMIT_DATE }}"
+
 # (Optional) Working directory. (default: root of the project)
 # dir: ./relative/path/to/dir
 

--- a/.slsa-goreleaser/windows-arm64.yml
+++ b/.slsa-goreleaser/windows-arm64.yml
@@ -19,6 +19,13 @@ flags:
   - -trimpath
   - -tags=withoutebpf # need by inspektor-gadget
 
+# (Optional) ldflags for version injection
+ldflags:
+  - "-X github.com/Azure/aks-mcp/internal/version.GitVersion={{ .Env.VERSION }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitCommit={{ .Env.COMMIT }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.GitTreeState={{ .Env.TREE_STATE }}"
+  - "-X github.com/Azure/aks-mcp/internal/version.BuildMetadata={{ .Env.COMMIT_DATE }}"
+
 # (Optional) Working directory. (default: root of the project)
 # dir: ./relative/path/to/dir
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,15 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the application for target platform
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o aks-mcp ./cmd/aks-mcp
+# Build the application for target platform with version injection
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -trimpath \
+    -tags withoutebpf \
+    -ldflags "-X github.com/Azure/aks-mcp/internal/version.GitVersion=${VERSION} \
+              -X github.com/Azure/aks-mcp/internal/version.GitCommit=${GIT_COMMIT} \
+              -X github.com/Azure/aks-mcp/internal/version.GitTreeState=${GIT_TREE_STATE} \
+              -X github.com/Azure/aks-mcp/internal/version.BuildMetadata=${BUILD_DATE}" \
+    -o aks-mcp ./cmd/aks-mcp
 
 # Runtime stage
 FROM alpine:3.22

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ DOCKER_IMAGE = aks-mcp
 DOCKER_TAG ?= latest
 
 # Version information
+# Version is automatically derived from git tags using 'git describe --tags --always --dirty'
+# This provides proper semantic versioning based on GitHub releases and tags
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 GIT_TREE_STATE ?= $(shell if git diff --quiet 2>/dev/null; then echo "clean"; else echo "dirty"; fi)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/aks-mcp/internal/security"
 	"github.com/Azure/aks-mcp/internal/telemetry"
+	"github.com/Azure/aks-mcp/internal/version"
 	flag "github.com/spf13/pflag"
 )
 
@@ -80,9 +81,12 @@ func (cfg *ConfigData) ParseFlags() {
 	// OTLP settings
 	flag.StringVar(&cfg.OTLPEndpoint, "otlp-endpoint", "", "OTLP endpoint for OpenTelemetry traces (e.g. localhost:4317)")
 
-	// Custom help handling.
+	// Custom help handling
 	var showHelp bool
 	flag.BoolVarP(&showHelp, "help", "h", false, "Show help message")
+
+	// Version flag
+	showVersion := flag.Bool("version", false, "Show version information and exit")
 
 	// Parse flags and handle errors properly
 	err := flag.CommandLine.Parse(os.Args[1:])
@@ -96,6 +100,12 @@ func (cfg *ConfigData) ParseFlags() {
 	if showHelp {
 		fmt.Printf("Usage of %s:\n", os.Args[0])
 		flag.PrintDefaults()
+		os.Exit(0)
+	}
+
+	// Handle version flag
+	if *showVersion {
+		cfg.PrintVersion()
 		os.Exit(0)
 	}
 
@@ -131,4 +141,14 @@ func (cfg *ConfigData) InitializeTelemetry(ctx context.Context, serviceName, ser
 
 	// Track MCP server startup
 	cfg.TelemetryService.TrackServiceStartup(ctx)
+}
+
+// PrintVersion prints version information
+func (cfg *ConfigData) PrintVersion() {
+	versionInfo := version.GetVersionInfo()
+	fmt.Printf("aks-mcp version %s\n", versionInfo["version"])
+	fmt.Printf("Git commit: %s\n", versionInfo["gitCommit"])
+	fmt.Printf("Git tree state: %s\n", versionInfo["gitTreeState"])
+	fmt.Printf("Go version: %s\n", versionInfo["goVersion"])
+	fmt.Printf("Platform: %s\n", versionInfo["platform"])
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,7 +8,7 @@ import (
 // Version information
 var (
 	// GitVersion is the git tag version
-	GitVersion = "1"
+	GitVersion = "dev"
 	// BuildMetadata is extra build time data
 	BuildMetadata = ""
 	// GitCommit is the git sha1


### PR DESCRIPTION
# Version System Improvements

## Current Problems
1. Hardcoded fallback version: The version.go file has GitVersion = "1" hardcoded
2. Docker builds don't inject version: The Dockerfile doesn't use ldflags to inject version info
3. SLSA builds missing ldflags: The goreleaser configs don't include version injection
4. Inconsistent version sources: Telemetry gets stale version info in containerized deployments

## Summary

The version system has been improved to properly integrate with Git tags and GitHub releases, ensuring that telemetry and version reporting reflect the actual released version rather than hardcoded values.

## Changes Made

### 1. Fixed Version Injection in Docker Builds
**Problem**: Docker builds were not injecting version information via ldflags.
**Solution**: Updated `Dockerfile` to use build arguments for version injection:

```dockerfile
RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
    -trimpath \
    -tags withoutebpf \
    -ldflags "-X github.com/Azure/aks-mcp/internal/version.GitVersion=${VERSION} \
              -X github.com/Azure/aks-mcp/internal/version.GitCommit=${GIT_COMMIT} \
              -X github.com/Azure/aks-mcp/internal/version.GitTreeState=${GIT_TREE_STATE} \
              -X github.com/Azure/aks-mcp/internal/version.BuildMetadata=${BUILD_DATE}" \
    -o aks-mcp ./cmd/aks-mcp
```

### 2. Updated SLSA Goreleaser Configurations
**Problem**: SLSA3 builds were not injecting version information.
**Solution**: Added ldflags to all `.slsa-goreleaser/*.yml` files:

```yaml
ldflags:
  - "-X github.com/Azure/aks-mcp/internal/version.GitVersion={{ .Env.VERSION }}"
  - "-X github.com/Azure/aks-mcp/internal/version.GitCommit={{ .Env.COMMIT }}"
  - "-X github.com/Azure/aks-mcp/internal/version.GitTreeState={{ .Env.TREE_STATE }}"
  - "-X github.com/Azure/aks-mcp/internal/version.BuildMetadata={{ .Env.COMMIT_DATE }}"
```

### 3. Improved Fallback Version
**Problem**: Hardcoded fallback version "1" was not descriptive.
**Solution**: Changed default version to "dev" for development builds.

### 4. Added Version Command
**Problem**: No easy way to check version of deployed binaries.
**Solution**: Added `--version` flag that prints comprehensive version information:

```bash
$ ./aks-mcp --version
aks-mcp version v0.0.5-34-g14e1d51-dirty+2025-08-15T01:44:54Z
Git commit: 14e1d51d4d29a0d99879a2b45646df3cbc4d34d8
Git tree state: dirty
Go version: go1.24.5
Platform: linux/amd64
```

## How It Works

### Version Detection Strategy

1. **Release Builds**: Use `git describe --tags --always --dirty` to get semantic version from Git tags
   - Example: `v1.2.3` (clean tag), `v1.2.3-5-g1234567` (commits after tag), `v1.2.3-dirty` (uncommitted changes)

2. **Development Builds**: Fall back to "dev" if no Git information is available

3. **CI/CD Integration**: GitHub Actions workflow automatically:
   - Extracts version from Git tags
   - Passes version info to all build processes (Docker, SLSA)
   - Ensures consistent versioning across all artifacts

### Telemetry Integration

The telemetry system now automatically receives the correct version:

```go
// In main.go
cfg.InitializeTelemetry(ctx, "aks-mcp", version.GetVersion())
```

This ensures that:
- Azure Monitor receives accurate version information
- OpenTelemetry traces include correct service version
- Application Insights can correlate issues with specific versions

## Benefits

1. **Accurate Telemetry**: Telemetry now reports the actual Git tag/version instead of hardcoded values
2. **Release Traceability**: Easy to identify which version is running in production
3. **Developer Experience**: `--version` flag provides comprehensive build information
4. **CI/CD Integration**: Automatic version detection from Git tags works seamlessly with GitHub releases
5. **Container Support**: Docker builds now properly inject version information

## Usage Examples

### Check Version of Binary
```bash
./aks-mcp --version
```

### Build with Version Information
```bash
make build  # Automatically detects version from Git
```

### Release Process
1. Create Git tag: `git tag v1.2.3`
2. Push tag: `git push origin v1.2.3`
3. GitHub Actions automatically builds with version `v1.2.3`
4. All artifacts (binaries, containers) include proper version info

### Docker Build
```bash
make docker-build  # Automatically passes version build args
```
