### PR TITLE
feat: add start and stop operations for AKS clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Unified tool for managing Azure Kubernetes Service (AKS) clusters and related op
   - `create`: Create new cluster
   - `delete`: Delete cluster
   - `scale`: Scale cluster node count
+  - `start`: Start a stopped cluster
+  - `stop`: Stop a running cluster
   - `update`: Update cluster configuration
   - `upgrade`: Upgrade Kubernetes version
   - `nodepool-add`: Add node pool to cluster

--- a/internal/components/azaks/registry.go
+++ b/internal/components/azaks/registry.go
@@ -18,6 +18,8 @@ const (
 	OpClusterCreate         AksOperationType = "create"
 	OpClusterDelete         AksOperationType = "delete"
 	OpClusterScale          AksOperationType = "scale"
+	OpClusterStart          AksOperationType = "start"
+	OpClusterStop           AksOperationType = "stop"
 	OpClusterUpdate         AksOperationType = "update"
 	OpClusterUpgrade        AksOperationType = "upgrade"
 	OpClusterGetVersions    AksOperationType = "get-versions"
@@ -51,7 +53,7 @@ func generateToolDescription(accessLevel string) string {
 
 	// Add read-write operations for readwrite and admin
 	if accessLevel == "readwrite" || accessLevel == "admin" {
-		clusterOps = append(clusterOps, "create", "delete", "scale", "update", "upgrade")
+		clusterOps = append(clusterOps, "create", "delete", "scale", "update", "upgrade", "start", "stop")
 		nodepoolOps = append(nodepoolOps, "nodepool-add", "nodepool-delete", "nodepool-scale", "nodepool-upgrade")
 		accountOps = append(accountOps, "account-set", "login")
 	}
@@ -122,9 +124,10 @@ func GetOperationAccessLevel(operation string) string {
 
 	readWriteOps := []string{
 		string(OpClusterCreate), string(OpClusterDelete), string(OpClusterScale),
-		string(OpClusterUpdate), string(OpClusterUpgrade), string(OpNodepoolAdd),
-		string(OpNodepoolDelete), string(OpNodepoolScale), string(OpNodepoolUpgrade),
-		string(OpAccountSet), string(OpLogin),
+		string(OpClusterUpdate), string(OpClusterUpgrade), string(OpClusterStart),
+		string(OpClusterStop), string(OpNodepoolAdd), string(OpNodepoolDelete),
+		string(OpNodepoolScale), string(OpNodepoolUpgrade), string(OpAccountSet),
+		string(OpLogin),
 	}
 
 	adminOps := []string{
@@ -177,6 +180,8 @@ func MapOperationToCommand(operation string) (string, error) {
 		string(OpClusterCreate):         "az aks create",
 		string(OpClusterDelete):         "az aks delete",
 		string(OpClusterScale):          "az aks scale",
+		string(OpClusterStart):          "az aks start",
+		string(OpClusterStop):           "az aks stop",
 		string(OpClusterUpdate):         "az aks update",
 		string(OpClusterUpgrade):        "az aks upgrade",
 		string(OpClusterGetVersions):    "az aks get-versions",
@@ -210,9 +215,9 @@ func GetSupportedOperations() []string {
 	return []string{
 		// Cluster operations
 		string(OpClusterShow), string(OpClusterList), string(OpClusterCreate),
-		string(OpClusterDelete), string(OpClusterScale), string(OpClusterUpdate),
-		string(OpClusterUpgrade), string(OpClusterGetVersions), string(OpClusterCheckNetwork),
-		string(OpClusterGetCredentials),
+		string(OpClusterDelete), string(OpClusterScale), string(OpClusterStart),
+		string(OpClusterStop), string(OpClusterUpdate), string(OpClusterUpgrade),
+		string(OpClusterGetVersions), string(OpClusterCheckNetwork), string(OpClusterGetCredentials),
 		// Nodepool operations
 		string(OpNodepoolList), string(OpNodepoolShow), string(OpNodepoolAdd),
 		string(OpNodepoolDelete), string(OpNodepoolScale), string(OpNodepoolUpgrade),

--- a/internal/components/azaks/registry_test.go
+++ b/internal/components/azaks/registry_test.go
@@ -25,7 +25,7 @@ func TestGetSupportedOperations_ContainsExpectedOps(t *testing.T) {
 	operations := GetSupportedOperations()
 
 	expectedOps := []string{
-		"show", "list", "create", "delete", "scale", "update", "upgrade",
+		"show", "list", "create", "delete", "scale", "start", "stop", "update", "upgrade",
 		"nodepool-list", "nodepool-show", "nodepool-add", "nodepool-delete",
 		"account-list", "account-set", "login", "get-credentials",
 	}
@@ -56,6 +56,12 @@ func TestValidateOperationAccess_ChecksAccessLevels(t *testing.T) {
 		{"create", "readonly", false},
 		{"create", "readwrite", true},
 		{"create", "admin", true},
+		{"start", "readonly", false},
+		{"start", "readwrite", true},
+		{"start", "admin", true},
+		{"stop", "readonly", false},
+		{"stop", "readwrite", true},
+		{"stop", "admin", true},
 		{"get-credentials", "readonly", false},
 		{"get-credentials", "readwrite", false},
 		{"get-credentials", "admin", true},


### PR DESCRIPTION
Added start and stop cluster operations to the azaks component, allowing users to start stopped clusters and stop running clusters.