### PR TITLE
fix: remove action_params as required for inspektor_gadget_observability tool

### DIFF
--- a/internal/components/inspektorgadget/registry.go
+++ b/internal/components/inspektorgadget/registry.go
@@ -28,7 +28,6 @@ func RegisterInspektorGadgetTool() mcp.Tool {
 		),
 		mcp.WithObject("action_params",
 			mcp.Description("Parameters for the action"),
-			mcp.Required(),
 			mcp.Properties(map[string]any{
 				"gadget_name": map[string]any{
 					"type":        "string",


### PR DESCRIPTION
fix: remove action_params as required for inspektor_gadget_observability tool

With this fix, some clients would report errors, e.g. 

BadRequestError - Invalid schema for function 'inspektor_gadget_observability': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Extra required key 'action_params' supplied.