### PR TITLE
feat: add helpful 404 responses for HTTP/SSE server endpoints

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/Azure/aks-mcp/internal/azcli"
 	"github.com/Azure/aks-mcp/internal/azureclient"
@@ -127,13 +128,16 @@ func (s *Service) createCustomHTTPServerWithHelp404(addr string) *http.Server {
 				},
 			}
 
-			json.NewEncoder(w).Encode(response)
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			}
 		}
 	})
 
 	return &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 }
 
@@ -161,13 +165,16 @@ func (s *Service) createCustomSSEServerWithHelp404(sseServer *server.SSEServer, 
 				},
 			}
 
-			json.NewEncoder(w).Encode(response)
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			}
 		}
 	})
 
 	return &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
Enhances user experience when accessing incorrect endpoints by providing:
- Custom 404 responses with JSON format for both SSE and streamable-http transports
- Clear guidance on correct MCP endpoint usage (/mcp, /sse, /message)
- Comprehensive test coverage for new HTTP server behavior

Fix #165 