### PR TITLE
remove: VMSS run-command tool for AKS policy compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,6 @@ Unified tool for Azure monitoring and diagnostics operations for AKS clusters.
 
 - Get detailed VMSS configuration for node pools in the AKS cluster
 
-**Tool:** `az_vmss_run-command_invoke` *(readwrite/admin only)*
-
-- Execute commands on Virtual Machine Scale Set instances
 
 </details>
 

--- a/internal/components/compute/executor.go
+++ b/internal/components/compute/executor.go
@@ -22,7 +22,7 @@ func (e *ComputeOperationsExecutor) Execute(params map[string]interface{}, cfg *
 	// Parse operation parameter
 	operation, ok := params["operation"].(string)
 	if !ok {
-		return "", fmt.Errorf("missing or invalid 'operation' parameter. Common operations: list, show, start, stop, restart, run-command, reimage. Example: operation=\"list\"")
+		return "", fmt.Errorf("missing or invalid 'operation' parameter. Common operations: list, show, start, stop, restart, reimage. Example: operation=\"list\"")
 	}
 
 	// Parse resource_type parameter
@@ -102,8 +102,6 @@ func (e *ComputeOperationsExecutor) Execute(params map[string]interface{}, cfg *
 			errorMsg += "\nTip: Verify the resource exists and check if it's already in the desired state"
 		case "reimage":
 			errorMsg += "\nTip: Verify the VMSS name is correct and the instances are ready for reimaging"
-		case "run-command":
-			errorMsg += "\nTip: Ensure the resource is running and the command syntax is correct. Use --command-id RunShellScript for shell commands"
 		}
 
 		return "", fmt.Errorf("%s\nExecuted command: %s", errorMsg, fullCommand)
@@ -124,10 +122,10 @@ func getSuggestedOperations(resourceType, accessLevel string) string {
 		switch resourceType {
 		case "vm":
 			// Only safe VM operations
-			operations = append(operations, "start", "stop", "restart", "run-command")
+			operations = append(operations, "start", "stop", "restart")
 		case "vmss":
 			// Only safe operations for AKS-managed VMSS
-			operations = append(operations, "restart", "reimage", "run-command")
+			operations = append(operations, "restart", "reimage")
 		}
 	}
 

--- a/internal/components/compute/unified_test.go
+++ b/internal/components/compute/unified_test.go
@@ -53,9 +53,6 @@ func TestValidateOperationAccess(t *testing.T) {
 		{"restart", "readonly", false},
 		{"restart", "readwrite", true},
 		{"restart", "admin", true},
-		{"run-command", "readonly", false},
-		{"run-command", "readwrite", true},
-		{"run-command", "admin", true},
 		{"reimage", "readonly", false},
 		{"reimage", "readwrite", true},
 		{"reimage", "admin", true},
@@ -89,13 +86,11 @@ func TestMapOperationToCommand(t *testing.T) {
 		// VM operations
 		{"show", "vm", "az vm show", true},
 		{"start", "vm", "az vm start", true},
-		{"run-command", "vm", "az vm run-command invoke", true},
 
 		// VMSS operations
 		{"show", "vmss", "az vmss show", true},
 		{"restart", "vmss", "az vmss restart", true},
 		{"reimage", "vmss", "az vmss reimage", true},
-		{"run-command", "vmss", "az vmss run-command invoke", true},
 		// Scale operation removed - not safe for AKS-managed VMSS
 
 		// Invalid resource types
@@ -140,7 +135,6 @@ func TestGetOperationAccessLevel(t *testing.T) {
 		{"stop", "readwrite"},
 		{"restart", "readwrite"},
 		{"reimage", "readwrite"},
-		{"run-command", "readwrite"},
 
 		// Unknown operations
 		{"invalid-op", "unknown"},

--- a/prompts/azure-vmss-tools.md
+++ b/prompts/azure-vmss-tools.md
@@ -35,35 +35,13 @@ Get detailed Virtual Machine Scale Set (VMSS) information for AKS node pools and
 - Per-node pool VMSS details or error messages
 - Complete VMSS configuration for each successfully retrieved node pool
 
-### `az_vmss_run-command_invoke`
-
-**Purpose**: Execute commands on Virtual Machine Scale Set instances (AKS node pools)
-
-**Parameters**:
-- `args` (required): Arguments for the `az vmss run-command invoke` command
-
-**Example Usage**:
-```
---name myVMSS --resource-group myResourceGroup --command-id RunShellScript --scripts 'echo Hello World' --instance-ids 0 1
-```
-
-**Returns**: Command execution results from the specified VMSS instances:
-- Exit codes and status for each instance
-- Command output (stdout/stderr)
-- Execution timestamps and duration
-- Error messages if command fails
-
-**Access Level**: Requires `readwrite` or `admin` access level
-
 ## Key Use Cases
 
 1. **Troubleshooting Node Issues**: Get detailed VM configuration when nodes aren't behaving as expected
-2. **Remote Command Execution**: Execute diagnostic commands, collect logs, or perform maintenance tasks on AKS nodes
-3. **Security Auditing**: Review VM extensions, security settings, and network configurations
-4. **Performance Analysis**: Check VM sizes, storage types, and networking setup
-5. **Compliance Checking**: Verify OS images, patches, and security configurations
-6. **Resource Planning**: Understand current VM configurations for capacity planning
-7. **Node Maintenance**: Run scripts to update configurations, restart services, or apply patches
+2. **Security Auditing**: Review VM extensions, security settings, and network configurations
+3. **Performance Analysis**: Check VM sizes, storage types, and networking setup
+4. **Compliance Checking**: Verify OS images, patches, and security configurations
+5. **Resource Planning**: Understand current VM configurations for capacity planning
 
 ## What You Get vs Standard AKS Commands
 
@@ -80,7 +58,6 @@ Get detailed Virtual Machine Scale Set (VMSS) information for AKS node pools and
 - Load balancer backend pool memberships
 - Detailed OS and image information
 - Scaling and upgrade policies
-- Remote command execution on VMSS instances
 
 ## Code Structure
 
@@ -134,9 +111,6 @@ func RegisterAzComputeCommand(cmd ComputeCommand) mcp.Tool {
 
 func GetReadWriteVmssCommands() []ComputeCommand {
     return []ComputeCommand{
-        {Name: "az vmss run-command invoke", 
-         Description: "...", 
-         ArgsExample: "..."},
     }
 }
 ```


### PR DESCRIPTION
Remove VMSS run-command functionality that violates AKS support policies by enabling out-of-band VM manipulation outside AKS-supported paths.

Changes:
- Remove OpVMRunCommand and OpVMSSRunCommand operation types
- Remove run-command from tool descriptions and examples
- Remove run-command from access level validation and command mapping
- Remove run-command test cases and error handling
- Update documentation to remove run-command references