### PR TITLE
chore: bump k8s tools and fix the tool list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ Unified tool for Azure monitoring and diagnostics operations for AKS clusters.
 
 - Get detailed VMSS configuration for node pools in the AKS cluster
 
+**Tool:** `az_compute_operations`
+
+Unified tool for managing Azure Virtual Machines (VMs) and Virtual Machine Scale Sets (VMSS) used by AKS.
+
+**Available Operations:**
+
+- `show`: Get details of a VM/VMSS
+- `list`: List VMs/VMSS in subscription or resource group
+- `get-instance-view`: Get runtime status
+- `start`: Start VM
+- `stop`: Stop VM
+- `restart`: Restart VM/VMSS instances
+- `reimage`: Reimage VMSS instances (VM not supported for reimage)
+
+**Resource Types:** `vm` (single virtual machines), `vmss` (virtual machine scale sets)
 
 </details>
 
@@ -220,20 +235,19 @@ Retrieve and manage Azure Advisor recommendations for AKS clusters.
 *Note: kubectl commands are available with all access levels. Additional tools
 require explicit enablement via `--additional-tools`*
 
-**kubectl Commands (Read-Only):**
+**kubectl Tools (Unified Interface):**
 
-- `kubectl_get`, `kubectl_describe`, `kubectl_explain`, `kubectl_logs`
-- `kubectl_api-resources`, `kubectl_api-versions`, `kubectl_diff`
-- `kubectl_cluster-info`, `kubectl_top`, `kubectl_events`, `kubectl_auth`
+- **Read-Only** (all access levels):
+  - `kubectl_resources`: View resources (get, describe) - filtered to read-only operations in readonly mode
+  - `kubectl_diagnostics`: Debug and diagnose (logs, events, top, exec, cp)
+  - `kubectl_cluster`: Cluster information (cluster-info, api-resources, api-versions, explain)
+  - `kubectl_config`: Configuration management (diff, auth, config) - filtered to read-only operations in readonly mode
 
-**kubectl Commands (Read-Write/Admin):**
-
-- `kubectl_create`, `kubectl_delete`, `kubectl_apply`, `kubectl_expose`,
-  `kubectl_run`
-- `kubectl_set`, `kubectl_rollout`, `kubectl_scale`, `kubectl_autoscale`
-- `kubectl_label`, `kubectl_annotate`, `kubectl_patch`, `kubectl_replace`
-- `kubectl_cp`, `kubectl_exec`, `kubectl_cordon`, `kubectl_uncordon`
-- `kubectl_drain`, `kubectl_taint`, `kubectl_certificate`
+- **Read-Write/Admin** (`readwrite`/`admin` access levels):
+  - `kubectl_resources`: Full resource management (get, describe, create, delete, apply, patch, replace, cordon, uncordon, drain, taint)
+  - `kubectl_workloads`: Workload lifecycle (run, expose, scale, autoscale, rollout)
+  - `kubectl_metadata`: Metadata management (label, annotate, set)
+  - `kubectl_config`: Full configuration management (diff, auth, certificate, config)
 
 **Additional Tools (Optional):**
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2 v2.2.1
-	github.com/Azure/mcp-kubernetes v0.0.8
+	github.com/Azure/mcp-kubernetes v0.0.9
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/inspektor-gadget/inspektor-gadget v0.43.0
 	github.com/mark3labs/mcp-go v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/Azure/mcp-kubernetes v0.0.8 h1:I12xT+EV0epjPR2CbXWIsYFjgAH9xeUUt2mKT5E6FnA=
-github.com/Azure/mcp-kubernetes v0.0.8/go.mod h1:H+UCYBw8V3dJGRwB+l+0doPuI/r6n8o1Wlj1kwI++wk=
+github.com/Azure/mcp-kubernetes v0.0.9 h1:IRVEAnJW8Eg1e4QTBiA3xSI8/vAdGeiuoq3bKfhrM1I=
+github.com/Azure/mcp-kubernetes v0.0.9/go.mod h1:8B91zFpju5S65I93OUSg4Ek8D4JGOpy0vbbVWbO8YAY=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJe7PpYPXT5A29ZkwJaPqcva7BVeemZOZs=


### PR DESCRIPTION
mcp-kubernetes bumped to support switching kubectl context.