### PR TITLE
Fix README WSL guidance to prevent ENOENT errors (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,19 +309,51 @@ Once started, the MCP server will appear in the **Copilot Chat: Configure Tools*
 
 Try a prompt like *"List all my AKS clusters"*, which will start using tools from the AKS-MCP server.
 
-Note:
-For VS Code that is runing inside of WSL environment, starting AKS MCP server could fail with error "Connection state: Error spawn /home/path/.vs-kubernetes/tools/aks-mcp/v0.0.3/aks-mcp ENOENT", it means VS code cannot find this file. The resolution is modifying the mcp.json file as following to make it running with wsl.
+#### WSL Configuration
+
+The MCP configuration differs depending on whether VS Code is running on Windows or inside WSL:
+
+**🪟 Windows Host (VS Code on Windows)**: Use `"command": "wsl"` to invoke the WSL binary from Windows:
 
 ```json
-"AKS MCP": {
-	"command": "wsl",
-	"args": [
-		"<aks-mcp path>",
-		"--transport",
-		"stdio"
-	]
+{
+  "servers": {
+    "aks-mcp": {
+      "type": "stdio",
+      "command": "wsl",
+      "args": [
+        "--",
+        "/home/you/.vs-kubernetes/tools/aks-mcp/aks-mcp",
+        "--transport",
+        "stdio"
+      ]
+    }
+  }
 }
 ```
+
+**🐧 Remote-WSL (VS Code running inside WSL)**: Call the binary directly or use a shell wrapper:
+
+```json
+{
+  "servers": {
+    "aks-mcp": {
+      "type": "stdio",
+      "command": "bash",
+      "args": [
+        "-c",
+        "/home/you/.vs-kubernetes/tools/aks-mcp/aks-mcp --transport stdio"
+      ]
+    }
+  }
+}
+```
+
+**🔧 Troubleshooting ENOENT Errors**
+
+If you see "spawn ENOENT" errors, verify your VS Code environment:
+- **Windows host**: Check if the WSL binary path is correct and accessible via `wsl -- ls /path/to/aks-mcp`
+- **Remote-WSL**: Do NOT use `"command": "wsl"` - use direct paths or bash wrapper as shown above
 
 
 > **💡 Benefits**: The AKS extension handles binary downloads, updates, and configuration automatically, ensuring you always have the latest version with optimal settings.


### PR DESCRIPTION
## Summary
- Fixes ambiguous WSL guidance that causes ENOENT errors in Remote-WSL setups
- Replaces the current note with clear, separate instructions for two scenarios:
  - **Windows host VS Code**: Use `"command": "wsl"` to invoke WSL binaries
  - **Remote-WSL (VS Code inside WSL)**: Use direct binary paths or bash wrapper
- Adds troubleshooting section to help users identify their environment and resolve spawn errors

## Background
The current README section (lines 313-325) suggests using `"command": "wsl"` for "VS Code running inside WSL environment", but this is misleading and causes the exact ENOENT error described in the issue. The `wsl` command is a Windows-side launcher that's not available inside the WSL environment when using the Remote-WSL extension.

## Related Issues
Closes #190