### PR TITLE
Include hubble in additional tools

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,7 +71,7 @@ func (cfg *ConfigData) ParseFlags() {
 
 	// Kubernetes-specific settings
 	additionalTools := flag.String("additional-tools", "",
-		"Comma-separated list of additional Kubernetes tools to support (kubectl is always enabled). Available: helm,cilium")
+		"Comma-separated list of additional Kubernetes tools to support (kubectl is always enabled). Available: helm,cilium,hubble")
 	flag.StringVar(&cfg.AllowNamespaces, "allow-namespaces", "",
 		"Comma-separated list of allowed Kubernetes namespaces (empty means all namespaces)")
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/aks-mcp/internal/version"
 	"github.com/Azure/mcp-kubernetes/pkg/cilium"
 	"github.com/Azure/mcp-kubernetes/pkg/helm"
+	"github.com/Azure/mcp-kubernetes/pkg/hubble"
 	"github.com/Azure/mcp-kubernetes/pkg/kubectl"
 	k8stools "github.com/Azure/mcp-kubernetes/pkg/tools"
 	"github.com/mark3labs/mcp-go/server"
@@ -335,8 +336,11 @@ func (s *Service) registerOptionalKubernetesComponents() {
 	// Register cilium if enabled
 	s.registerCiliumComponent()
 
+	// Register hubble if enabled
+	s.registerHubbleComponent()
+
 	// Log if no optional components are enabled
-	if !s.cfg.AdditionalTools["helm"] && !s.cfg.AdditionalTools["cilium"] {
+	if !s.cfg.AdditionalTools["helm"] && !s.cfg.AdditionalTools["cilium"] && !s.cfg.AdditionalTools["hubble"] {
 		log.Println("No optional Kubernetes components enabled")
 	}
 }
@@ -441,5 +445,15 @@ func (s *Service) registerCiliumComponent() {
 		ciliumTool := cilium.RegisterCilium()
 		ciliumExecutor := k8s.WrapK8sExecutor(cilium.NewExecutor())
 		s.mcpServer.AddTool(ciliumTool, tools.CreateToolHandler(ciliumExecutor, s.cfg))
+	}
+}
+
+// registerHubbleComponent registers hubble tools if enabled
+func (s *Service) registerHubbleComponent() {
+	if s.cfg.AdditionalTools["hubble"] {
+		log.Println("Registering Kubernetes tool: hubble")
+		hubbleTool := hubble.RegisterHubble()
+		hubbleExecutor := k8s.WrapK8sExecutor(hubble.NewExecutor())
+		s.mcpServer.AddTool(hubbleTool, tools.CreateToolHandler(hubbleExecutor, s.cfg))
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -35,7 +35,7 @@ func (m *MockToolCounter) AddTool(toolName string) {
 
 	// Categorize tools
 	azureToolPrefixes := []string{"az_", "azure_", "get_aks_", "list_detectors", "run_detector", "inspektor_gadget_observability"}
-	k8sToolPrefixes := []string{"kubectl_", "k8s_", "helm", "cilium"}
+	k8sToolPrefixes := []string{"kubectl_", "k8s_", "helm", "cilium", "hubble"}
 
 	isAzureTool := false
 	for _, prefix := range azureToolPrefixes {
@@ -119,6 +119,7 @@ func TestService(t *testing.T) {
 			additionalTools: map[string]bool{
 				"helm":   true,
 				"cilium": true,
+				"hubble": true,
 			},
 			expectedAzureTools: 8, // Same as readonly (Inspektor Gadget now included automatically)
 			expectedK8sTools:   0, // Will be calculated + 2 optional tools
@@ -144,6 +145,9 @@ func TestService(t *testing.T) {
 				optionalToolsCount++
 			}
 			if tt.additionalTools["cilium"] {
+				optionalToolsCount++
+			}
+			if tt.additionalTools["hubble"] {
 				optionalToolsCount++
 			}
 
@@ -242,6 +246,7 @@ func TestComponentToolCounts(t *testing.T) {
 		t.Logf("Optional Kubernetes Components:")
 		t.Logf("  - Helm: 1 tool (when enabled)")
 		t.Logf("  - Cilium: 1 tool (when enabled)")
+		t.Logf("  - Hubble: 1 tool (when enabled)")
 		t.Logf("Note: Inspektor Gadget is now automatically enabled as part of Azure Components")
 	})
 
@@ -344,7 +349,7 @@ func TestExpectedToolsByAccessLevel(t *testing.T) {
 
 			t.Logf("Kubernetes Tools:")
 			t.Logf("  - Kubectl Tools: %d", k8sToolsCount)
-			t.Logf("  - Optional Tools: 0-2 (helm, cilium)")
+			t.Logf("  - Optional Tools: 0-3 (helm, cilium, hubble)")
 
 			t.Logf("kubectl tools for %s:", level)
 			for i, tool := range kubectlTools {


### PR DESCRIPTION
This pull request adds support for the "hubble" Kubernetes tool as an optional component alongside existing tools like "helm" and "cilium". The changes update configuration, server registration logic, and tests to recognize and properly handle "hubble" as an optional tool.

**Kubernetes tool support:**

* Updated the `ParseFlags` method in `config.go` to include "hubble" as an available value for the `--additional-tools` flag.
* Added the `hubble` package import and implemented the `registerHubbleComponent` method in `server.go` to register the Hubble tool if enabled, and updated the logic that checks for enabled optional components. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R27) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R339-R343) [[3]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R450-R459)

**Testing and tool categorization:**

* Updated the tool categorization logic in `server_test.go` to recognize "hubble" as a Kubernetes tool, and adjusted test cases to include "hubble" in expected tool counts and logging. [[1]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92L38-R38) [[2]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92R122) [[3]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92R150-R152) [[4]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92R249) [[5]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92L347-R352)

## Related issue
Fixes #199 