### PR TITLE
fix: update user-assigned managed identity authentication to use --client-id

### DIFF
--- a/internal/azcli/login.go
+++ b/internal/azcli/login.go
@@ -132,7 +132,7 @@ func EnsureAzCliLoginWithProc(proc Proc, cfg *config.ConfigData) (string, error)
 
 	// 3) User-assigned Managed Identity (client ID provided)
 	if clientID != "" {
-		if err := runLoginCommand(proc, fmt.Sprintf("login --identity -u %s", clientID), "user-assigned managed identity"); err != nil {
+		if err := runLoginCommand(proc, fmt.Sprintf("login --identity --client-id %s", clientID), "user-assigned managed identity"); err != nil {
 			return "", err
 		}
 		if err := setSubscription(proc, subscriptionID, "user-assigned managed identity"); err != nil {

--- a/internal/azcli/login_test.go
+++ b/internal/azcli/login_test.go
@@ -263,7 +263,7 @@ func TestEnsureAzCliLogin_ManagedIdentity_UserAssigned(t *testing.T) {
 	t.Setenv("AZURE_SUBSCRIPTION_ID", "dummy-subscription-id")
 
 	p := &loginCommands{resp: []loginCommandResponses{
-		{cmd: "login --identity -u dummy-managed-identity-client-id", out: "", err: nil},
+		{cmd: "login --identity --client-id dummy-managed-identity-client-id", out: "", err: nil},
 		{cmd: "account set --subscription dummy-subscription-id", out: "", err: nil},
 		{cmd: "account show --query id -o tsv", out: "sub-id", err: nil},
 	}}
@@ -335,7 +335,7 @@ func TestEnsureAzCliLogin_LoginPromptInOutput(t *testing.T) {
 	// After the command.go fix, stderr content is returned WITH the error, not instead of it
 	// This test ensures we don't incorrectly think there's a valid login when there isn't
 	p := &loginCommands{resp: []loginCommandResponses{
-		{cmd: "login --identity -u cid", out: "", err: nil},
+		{cmd: "login --identity --client-id cid", out: "", err: nil},
 		{cmd: "account show --query id -o tsv", out: "sub-id", err: nil},
 	}}
 


### PR DESCRIPTION
The Azure CLI has deprecated the -u/--username flag for managed identity login. This change updates the authentication command to use --client-id instead, which is the current supported approach.

- Updated login.go to use --client-id instead of -u for user-assigned managed identity
- Updated corresponding unit tests to reflect the new command format

Fixes #205