### PR TITLE
feat: add kubelogin to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,14 @@ RUN echo $TARGETARCH; curl -LO "https://dl.k8s.io/release/$(curl -L -s https://d
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl
 
+# Install kubelogin
+RUN KUBELOGIN_VERSION="v0.2.10" && \
+    curl -LO "https://github.com/Azure/kubelogin/releases/download/${KUBELOGIN_VERSION}/kubelogin-linux-${TARGETARCH}.zip" && \
+    unzip kubelogin-linux-${TARGETARCH}.zip && \
+    mv bin/linux_${TARGETARCH}/kubelogin /usr/local/bin/kubelogin && \
+    chmod +x /usr/local/bin/kubelogin && \
+    rm -r bin/linux_${TARGETARCH} kubelogin-linux-${TARGETARCH}.zip
+
 # Install helm
 RUN HELM_ARCH=${TARGETARCH} && \
     curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \


### PR DESCRIPTION
This change adds [kubelogin](https://github.com/Azure/kubelogin) to the Dockerfile to allow clusters using Microsoft Entra authentication when using docker. 

## Testing Done

```
$ az aks get-credentials --resource-group qasim-rg --name qasim-entra-cluster --overwrite-existing
$ kubelogin convert-kubeconfig -l azurecli
$ docker run --rm -it --user 1000 -v $HOME/.azure:/home/mcp/.azure -v $HOME/.kube/config:/home/mcp/.kube/config --entrypoint=bash mcp/aks
cb5b4ba3b033:~$ kubectl get pods
No resources found in default namespace.
```