### PR TITLE
refactor: extract operation value extraction logic

### DIFF
--- a/internal/tools/handler.go
+++ b/internal/tools/handler.go
@@ -48,8 +48,7 @@ func CreateToolHandler(executor CommandExecutor, cfg *config.ConfigData) func(ct
 
 		result, err := executor.Execute(args, cfg)
 		if cfg.TelemetryService != nil {
-			operation, _ := args["operation"].(string)
-			cfg.TelemetryService.TrackToolInvocation(ctx, req.Params.Name, operation, err == nil)
+			cfg.TelemetryService.TrackToolInvocation(ctx, req.Params.Name, getOperationValue(args), err == nil)
 		}
 
 		logToolResult(req.Params.Name, result, err)
@@ -85,8 +84,7 @@ func CreateResourceHandler(handler ResourceHandler, cfg *config.ConfigData) func
 
 		// Track tool invocation with minimal data
 		if cfg.TelemetryService != nil {
-			operation, _ := args["operation"].(string)
-			cfg.TelemetryService.TrackToolInvocation(ctx, req.Params.Name, operation, err == nil)
+			cfg.TelemetryService.TrackToolInvocation(ctx, req.Params.Name, getOperationValue(args), err == nil)
 		}
 
 		logToolResult(req.Params.Name, result, err)
@@ -101,4 +99,14 @@ func CreateResourceHandler(handler ResourceHandler, cfg *config.ConfigData) func
 
 		return mcp.NewToolResultText(result), nil
 	}
+}
+
+func getOperationValue(args map[string]interface{}) string {
+	if op, _ := args["operation"].(string); op != "" {
+		return op
+	}
+	if action, _ := args["action"].(string); action != "" {
+		return action
+	}
+	return ""
 }

--- a/internal/tools/handler_test.go
+++ b/internal/tools/handler_test.go
@@ -295,3 +295,30 @@ func TestCreateToolHandler_Error_Verbose_LogErrorBranch(t *testing.T) {
 		t.Fatalf("expected error result, got: %+v", res)
 	}
 }
+
+func TestGetOperationValuePrefersOperation(t *testing.T) {
+	args := map[string]any{
+		"operation": "metrics",
+		"action":    "run",
+	}
+
+	if got := getOperationValue(args); got != "metrics" {
+		t.Fatalf("expected operation to win, got %q", got)
+	}
+}
+
+func TestGetOperationValueFallsBackToAction(t *testing.T) {
+	args := map[string]any{
+		"action": "deploy",
+	}
+
+	if got := getOperationValue(args); got != "deploy" {
+		t.Fatalf("expected action fallback, got %q", got)
+	}
+}
+
+func TestGetOperationValueHandlesMissingKeys(t *testing.T) {
+	if got := getOperationValue(map[string]any{}); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}


### PR DESCRIPTION
Extract getOperationValue function to handle both "operation" and "action" parameters for telemetry tracking, with fallback logic and proper empty string handling.

Without this, some tool's operation would be empty in telemetry.