### PR TITLE
fix: enforce json output for az monitor metrics and aks tools

### DIFF
--- a/internal/components/azaks/executor_test.go
+++ b/internal/components/azaks/executor_test.go
@@ -1,0 +1,68 @@
+package azaks
+
+import "testing"
+
+func TestEnsureOutputFormatArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "empty args",
+			input: "",
+			want:  "--output json",
+		},
+		{
+			name:  "already has long output flag",
+			input: "--resource-group rg --output table",
+			want:  "--resource-group rg --output table",
+		},
+		{
+			name:  "already has long output flag equals",
+			input: "--output=json --resource-group rg",
+			want:  "--output=json --resource-group rg",
+		},
+		{
+			name:  "already has short output flag",
+			input: "-o json --name test",
+			want:  "-o json --name test",
+		},
+		{
+			name:  "already has short compact output flag",
+			input: "-ojson --name test",
+			want:  "-ojson --name test",
+		},
+		{
+			name:  "no output flag appends json",
+			input: "--name test --resource-group rg",
+			want:  "--name test --resource-group rg --output json",
+		},
+		{
+			name:    "malformed args returns error",
+			input:   "--name \"missing-end",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ensureOutputFormatArgs(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/components/monitor/handlers_test.go
+++ b/internal/components/monitor/handlers_test.go
@@ -4,6 +4,54 @@ import (
 	"testing"
 )
 
+func TestEnsureOutputArg(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		out  []string
+	}{
+		{
+			name: "appends when missing",
+			in:   []string{"--name", "test"},
+			out:  []string{"--name", "test", "--output", "json"},
+		},
+		{
+			name: "no change with long flag",
+			in:   []string{"--name", "test", "--output", "table"},
+			out:  []string{"--name", "test", "--output", "table"},
+		},
+		{
+			name: "no change with equals",
+			in:   []string{"--output=json", "--name", "test"},
+			out:  []string{"--output=json", "--name", "test"},
+		},
+		{
+			name: "no change with short flag",
+			in:   []string{"-o", "table", "--name", "test"},
+			out:  []string{"-o", "table", "--name", "test"},
+		},
+		{
+			name: "no change with combined short flag",
+			in:   []string{"-otable", "--name", "test"},
+			out:  []string{"-otable", "--name", "test"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ensureOutputArg(tc.in)
+			if len(result) != len(tc.out) {
+				t.Fatalf("length mismatch: got %d, want %d", len(result), len(tc.out))
+			}
+			for i := range tc.out {
+				if result[i] != tc.out[i] {
+					t.Fatalf("index %d mismatch: got %q, want %q", i, result[i], tc.out[i])
+				}
+			}
+		})
+	}
+}
+
 func TestHandleAppInsightsQuery_ValidParameters(t *testing.T) {
 	params := map[string]interface{}{
 		"subscription_id":   "test-subscription",


### PR DESCRIPTION
This pull request introduces logic to ensure that all Azure CLI commands executed by our code default to JSON output unless an explicit output format is specified. This helps standardize command responses and makes downstream processing more predictable. The changes are implemented for both string-based and slice-based argument handling, with comprehensive unit tests added for each helper.

**Output format enforcement:**

* Added the `ensureOutputFormatArgs` helper to `internal/components/azaks/executor.go` to append `--output json` to command-line arguments when no output format is specified, using `shlex` for robust argument parsing. [[1]](diffhunk://#diff-0f53017a0d593ddfa97e3f9589f8d2242cae4c701bfb419171ed29f1ab7baf78R10) [[2]](diffhunk://#diff-0f53017a0d593ddfa97e3f9589f8d2242cae4c701bfb419171ed29f1ab7baf78R35-R40) [[3]](diffhunk://#diff-0f53017a0d593ddfa97e3f9589f8d2242cae4c701bfb419171ed29f1ab7baf78R101-R128)
* Added the `ensureOutputArg` helper to `internal/components/monitor/handlers.go` for slice-based argument lists, ensuring `--output json` is present unless an output flag is already specified. [[1]](diffhunk://#diff-230c38a03aa06da15862222e8d95d999add03c8933e3e97e74f6850502695cbfR332-R333) [[2]](diffhunk://#diff-230c38a03aa06da15862222e8d95d999add03c8933e3e97e74f6850502695cbfR392-R410)

**Testing:**

* Added unit tests for `ensureOutputFormatArgs` in `internal/components/azaks/executor_test.go` to cover various scenarios, including malformed input.
* Added unit tests for `ensureOutputArg` in `internal/components/monitor/handlers_test.go` to verify correct behavior for different argument combinations.