### PR TITLE
Fix: /heath for http, sse

### DIFF
--- a/internal/auth/oauth/endpoints.go
+++ b/internal/auth/oauth/endpoints.go
@@ -119,9 +119,6 @@ func (em *EndpointManager) RegisterEndpoints(mux *http.ServeMux) {
 
 	// OAuth 2.0 token endpoint for Authorization Code exchange
 	mux.HandleFunc("/oauth2/v2.0/token", em.tokenHandler())
-
-	// Health check endpoint (unauthenticated)
-	mux.HandleFunc("/health", em.healthHandler())
 }
 
 // authServerMetadataProxyHandler proxies authorization server metadata from Azure AD
@@ -365,38 +362,6 @@ func (em *EndpointManager) tokenIntrospectionHandler() http.HandlerFunc {
 			"aud":       tokenInfo.Audience,
 			"iss":       tokenInfo.Issuer,
 			"exp":       tokenInfo.ExpiresAt.Unix(),
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-			return
-		}
-	}
-}
-
-// healthHandler provides a simple health check endpoint
-func (em *EndpointManager) healthHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Set CORS headers for all requests
-		em.setCORSHeaders(w, r)
-
-		// Handle preflight OPTIONS request
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-
-		if r.Method != http.MethodGet {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		response := map[string]interface{}{
-			"status": "healthy",
-			"oauth": map[string]interface{}{
-				"enabled": em.cfg.OAuthConfig.Enabled,
-			},
 		}
 
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This pull request refactors the health check endpoint implementation by moving it from the OAuth endpoint manager to the main server service. The health endpoint is now always available, independent of OAuth configuration, and its response has been expanded to include additional fields. Corresponding tests and endpoint documentation have been updated to reflect these changes.

**Health Endpoint Refactor:**

* The `/health` endpoint and its handler have been removed from `EndpointManager` in `internal/auth/oauth/endpoints.go`, and all related tests have been deleted or updated. [[1]](diffhunk://#diff-81256a7fab62c9ee3a7379f9916a60be98e2fc61293b3c89eb48feffd95eb0c4L122-L124) [[2]](diffhunk://#diff-81256a7fab62c9ee3a7379f9916a60be98e2fc61293b3c89eb48feffd95eb0c4L378-L409) [[3]](diffhunk://#diff-209212e70f7e6b7f78be7f7257f525f4efd6a38fa948c85ef3464f66befc55c1L56) [[4]](diffhunk://#diff-209212e70f7e6b7f78be7f7257f525f4efd6a38fa948c85ef3464f66befc55c1L195-L229) [[5]](diffhunk://#diff-209212e70f7e6b7f78be7f7257f525f4efd6a38fa948c85ef3464f66befc55c1L491-R461)
* A new `healthHandler` is implemented in `Service` (`internal/server/server.go`), making the health endpoint always available regardless of OAuth configuration. The handler now returns additional fields: `version` and `transport` alongside `status` and OAuth info.

**Server Routing and Documentation Updates:**

* The `/health` endpoint is registered in both HTTP and SSE servers, and routing logic is updated so `/health` is always handled and documented in 404 responses. Endpoint descriptions are updated to include `/health`. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L197-R225) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R237) [[3]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L219) [[4]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R272-R274) [[5]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L269-R300) [[6]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R310) [[7]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L295)

**Test Updates:**

* Tests for the HTTP and SSE servers are updated to expect the `/health` endpoint to return a healthy status and the new response format, including checks for `version`, `transport`, and OAuth fields. [[1]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92L439-R439) [[2]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92R469-R487) [[3]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92L489-R514) [[4]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92L538-R558) [[5]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92R588-R606) [[6]](diffhunk://#diff-37049e37b989d9dc4f0c6df7b68cac427f3bbe573ddb717e066ffdb6a0bd4d92R650)