### PR TITLE
inspektor-gadget: Add tcpdump gadget

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ eBPF.
 - `observe_system_calls`: Monitor system calls
 - `top_file`: Top files by I/O operations
 - `top_tcp`: Top TCP connections by traffic
+- `tcpdump`: Capture network packets
 
 </details>
 

--- a/docs/inspektor-gadget-usage.md
+++ b/docs/inspektor-gadget-usage.md
@@ -27,6 +27,7 @@ In terms of the type of data collected, it includes:
 - **observe_system_calls**: Provides comprehensive system-level interaction data for debugging and performance analysis.
 - **top_file**: Displays files with the highest read/write operations to pinpoint frequently accessed files and performance bottlenecks.
 - **top_tcp**: Shows TCP connections sorted by traffic volume to identify high-traffic connections and network issues.
+- **tcpdump**: Captures network traffic to troubleshoot network connectivity issues and identify potential security issues.
 
 All the gadgets can be run for a specific pod or namespace. Also, if the user runs the MCP server with `--allow-namespaces=default,kube-system`, the data will be
 limited to the specified namespaces otherwise it will be collected for all namespaces.  The gadgets also have use-case-specific parameters that can be passed to customize the data collection.
@@ -63,6 +64,10 @@ Can you give me the top 3 pods with highest traffic in the AKS cluster?
 
 ```
 Can you observe system calls for the pod my-pod in the default namespace for few seconds? I want to understand why it migth be slow.
+```
+
+```
+Can you capture network traffic for the pod my-pod in the default namespace for 15 seconds? I want to debug connectivity issues.
 ```
 
 ## Prerequisites

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/mcp-kubernetes v0.0.9
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/gopacket/gopacket v1.4.0
 	github.com/inspektor-gadget/inspektor-gadget v0.45.0
 	github.com/mark3labs/mcp-go v0.41.1
 	github.com/microsoft/ApplicationInsights-Go v0.4.4

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopacket/gopacket v1.4.0 h1:cr1OlFpzksCkZHNO0eLjaSSOrMQnpPXg0j6qHIY3y2U=
+github.com/gopacket/gopacket v1.4.0/go.mod h1:EpvsxINeehp5qj4YMKMLf2/dekdhKn2IIAO/ZOifS7o=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/internal/components/inspektorgadget/const.go
+++ b/internal/components/inspektorgadget/const.go
@@ -38,6 +38,7 @@ const (
 	paramFetchInterval    = "operator.oci.ebpf.map-fetch-interval"
 	paramFilter           = "operator.filter.filter"
 	paramTraceloopSyscall = "operator.oci.wasm.syscall-filters"
+	paramPacketFilter     = "operator.oci.ebpf.pf"
 )
 
 // Inspektor Gadget Helm chart constants
@@ -58,4 +59,5 @@ const (
 	observeSystemCalls      = "observe_system_calls"
 	topFile                 = "top_file"
 	topTCP                  = "top_tcp"
+	tcpdump                 = "tcpdump"
 )

--- a/internal/components/inspektorgadget/gadgets.go
+++ b/internal/components/inspektorgadget/gadgets.go
@@ -267,6 +267,44 @@ var gadgets = []Gadget{
 			}
 		},
 	},
+	{
+		Name:        tcpdump,
+		Image:       "ghcr.io/inspektor-gadget/gadget/tcpdump",
+		Description: "Captures network traffic in the cluster",
+		Params: map[string]interface{}{
+			"pcap-filter": map[string]interface{}{
+				"type": "string",
+				"description": `Parses tcpdump/BPF-style filter expressions for network packet filtering.
+				Syntax:
+				expression = [not] [direction] [protocol] type [id] | expression and expression | expression or expression | ( expression )
+                Qualifiers:
+				  direction = src | dst | src or dst | src and dst
+				  protocol = ether | fddi | tr | wlan | ip | ip6 | arp | rarp | decnet | tcp | udp | icmp | igmp | atalk | aarp | vlan | ppptalk | pptp | sctp | mpls
+				  type = host | net | port | portrange | less | greater | gateway | proto (protocol)
+				  id = address | number
+				Examples:
+				  host 192.168.1.1
+				  src port 80
+				  tcp dst port 443
+				  not src host 10.0.0.1
+				  (src port 22) and (dst host 192.168.1.1)
+				  ip6 and not tcp
+				  proto icmp
+				  ether host aa:bb:cc:dd:ee:ff
+				  src or dst port 80 or 443
+				`,
+			},
+		},
+		ParamsFunc: func(filterParams map[string]interface{}, gadgetParams map[string]string) {
+			tcpdumpParams, ok := getGadgetParam(filterParams, tcpdump)
+			if !ok {
+				return
+			}
+			if filter, ok := tcpdumpParams["pcap-filter"].(string); ok && filter != "" {
+				gadgetParams[paramPacketFilter] = filter
+			}
+		},
+	},
 }
 
 func getGadgetNames() []string {


### PR DESCRIPTION
This change adds support for the [tcpdump](https://inspektor-gadget.io/docs/latest/gadgets/tcpdump/) gadget to the AKS MCP server, enabling users to troubleshoot networking issues more effectively. The gadget supports both Kubernetes and pcap-style filtering, allowing users to precisely target traffic captures when needed.

Fixes #224 

## Testing Done

### Prompt: 

Can you capture network traffic for the pod dns-request-pod in the default namespace for 15 seconds? I want to debug connectivity issues

### Response:

<img width="1118" height="1620" alt="image" src="https://github.com/user-attachments/assets/5fc839c5-f2f6-4824-ae22-028ac728cc69" />

