### PR TITLE
inspektor-gadget: Allow Deploy/Undeploy with default permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ eBPF.
 
 **Available Actions:**
 
-- `deploy`: Deploy Inspektor Gadget to cluster (requires `readwrite`/`admin` access)
-- `undeploy`: Remove Inspektor Gadget from cluster (requires `readwrite`/`admin` access)
+- `deploy`: Deploy Inspektor Gadget to cluster
+- `undeploy`: Remove Inspektor Gadget from cluster
 - `is_deployed`: Check deployment status
 - `run`: Run one-shot gadgets
 - `start`: Start continuous gadgets

--- a/docs/inspektor-gadget-usage.md
+++ b/docs/inspektor-gadget-usage.md
@@ -73,7 +73,7 @@ Can you capture network traffic for the pod my-pod in the default namespace for 
 ## Prerequisites
 
 - A kubeconfig file that has access to the AKS cluster.
-- The tool requires Inspektor Gadget to be installed in the cluster. If you are running with `--access-level=readwrite` or more, the MCP server will automatically
+- The tool requires Inspektor Gadget to be installed in the cluster. The MCP server will automatically
   install Inspektor Gadget (action `deploy` ) in the cluster otherwise you can follow the steps to install it manually: [Inspektor Gadget Installation](https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/logs/capture-system-insights-from-aks#how-to-install-inspektor-gadget-in-an-aks-cluster) or
   use the official Helm chart: [Inspektor Gadget Helm Chart](https://inspektor-gadget.io/docs/latest/reference/install-kubernetes#installation-with-the-helm-chart):
 
@@ -81,5 +81,3 @@ Can you capture network traffic for the pod my-pod in the default namespace for 
 IG_VERSION=$(curl -s https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest | jq -r '.tag_name' | sed 's/^v//')
 helm install gadget --namespace=gadget --create-namespace oci://ghcr.io/inspektor-gadget/inspektor-gadget/charts/gadget --version=$IG_VERSION
 ```
-
-Once Inspektor Gadget is deployed (or you installed it manually), you only need `readonly` (default) access to use the `inspektor_gadget_observability` tool.

--- a/internal/components/inspektorgadget/handlers.go
+++ b/internal/components/inspektorgadget/handlers.go
@@ -17,13 +17,7 @@ import (
 // Inspektor Gadget Handler
 // =============================================================================
 
-var (
-	defaultHelmCmd    = fmt.Sprintf("helm install %s --namespace=%s --create-namespace %s --version=%s", inspektorGadgetChartRelease, inspektorGadgetChartNamespace, inspektorGadgetChartURL, getChartVersion())
-	defaultKubectlCmd = fmt.Sprintf("kubectl apply -f https://github.com/inspektor-gadget/inspektor-gadget/releases/download/v%s/inspektor-gadget-v%s.yaml", getChartVersion(), getChartVersion())
-)
-
-var ErrNotDeployed = fmt.Errorf("inspektor gadget is not deployed, please deploy it first using: 'inspektor_gadget_observability' tool (action: deploy) (requires 'readwrite' or 'admin' access level)\n"+
-	"or running either of the command manually:\n%s\nor\n%s", defaultHelmCmd, defaultKubectlCmd)
+var ErrNotDeployed = fmt.Errorf("inspektor gadget is not deployed, please deploy it first using: 'inspektor_gadget_observability' tool (action: deploy)")
 
 // InspektorGadgetHandler returns a handler to manage gadgets
 func InspektorGadgetHandler(mgr GadgetManager, cfg *config.ConfigData) tools.ResourceHandler {
@@ -233,12 +227,6 @@ func handleLifecycleAction(mgr GadgetManager, deployed bool, action string, acti
 	// TODO: use security.Validator once helm readwrite/admin operations are implemented
 	if !cfg.SecurityConfig.IsNamespaceAllowed(inspektorGadgetChartNamespace) {
 		return "", fmt.Errorf("namespace %s is not allowed by security policy", inspektorGadgetChartNamespace)
-	}
-	if (cfg.AccessLevel != "readwrite" && cfg.AccessLevel != "admin") && (!slices.Contains(getReadonlyLifecycleActions(), action)) {
-		if action == deployAction {
-			return "", fmt.Errorf("action %q requires 'readwrite' or 'admin' access level, current access level is '%s'. %s", action, cfg.AccessLevel, ErrNotDeployed.Error())
-		}
-		return "", fmt.Errorf("action %q requires 'readwrite' or 'admin' access level, current access level is '%s'", action, cfg.AccessLevel)
 	}
 
 	installedVersion, err := mgr.GetVersion()

--- a/internal/components/inspektorgadget/helpers.go
+++ b/internal/components/inspektorgadget/helpers.go
@@ -154,11 +154,6 @@ func getLifecycleActions() []string {
 	return []string{deployAction, undeployAction, upgradeAction, isDeployedAction}
 }
 
-// getReadonlyLifecycleActions returns all valid readonly lifecycle actions for Inspektor Gadget.
-func getReadonlyLifecycleActions() []string {
-	return []string{isDeployedAction}
-}
-
 // isValidAction checks if the provided action is a valid action for Inspektor Gadget.
 func isValidAction(action string) bool {
 	return action == runAction || action == startAction || action == stopAction ||


### PR DESCRIPTION
This change will allow deploying/undeploying Inspektor Gadget with default permission, improving the user-experience by allowing them to deploy Inspkektor Gadget without extra manual steps (e.g setting up `readwrite` permission or manually deploying IG)

Given we only install in a specific namespace (`gadget`) and already have ways to ensure we [don't try to manage](https://github.com/Azure/aks-mcp/blob/main/internal/components/inspektorgadget/handlers.go#L298) any existing installation it should be fine to remove the requirement of `readwrite` permissions.

cc: @julia-yin  