### PR TITLE
inspektor-gadget: Include confirmation before deploy/undeploy

### DIFF
--- a/internal/components/inspektorgadget/handlers.go
+++ b/internal/components/inspektorgadget/handlers.go
@@ -229,6 +229,14 @@ func handleLifecycleAction(mgr GadgetManager, deployed bool, action string, acti
 		return "", fmt.Errorf("namespace %s is not allowed by security policy", inspektorGadgetChartNamespace)
 	}
 
+	con, ok := actionParams["confirm"].(bool)
+	if !ok {
+		con = false
+	}
+	if cfg.AccessLevel == "readonly" && action != isDeployedAction && !con {
+		return "", fmt.Errorf("confirmation required to deploy/upgrade/undeploy Inspektor Gadget when running server in 'readonly' mode. Note this will create/modify resources in the %s namespace. Should we proceed?", inspektorGadgetChartNamespace)
+	}
+
 	installedVersion, err := mgr.GetVersion()
 	if err != nil && deployed {
 		return "", fmt.Errorf("getting installed version: %w", err)

--- a/internal/components/inspektorgadget/registry.go
+++ b/internal/components/inspektorgadget/registry.go
@@ -1,8 +1,9 @@
 package inspektorgadget
 
 import (
-	"github.com/mark3labs/mcp-go/mcp"
 	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // =============================================================================
@@ -17,9 +18,10 @@ func RegisterInspektorGadgetTool() mcp.Tool {
 			"Apart from 'action' param:\n\n"+
 			"It supports 'action_params' (type=object) to specify parameters for the action."+
 			"Available params are: "+
-			"gadget_name, duration, gadget_id, chart_version. "+
+			"gadget_name, duration, gadget_id, chart_version, confirm (only if user explicitly wants to perform the action in 'readonly' mode)."+
 			"Available Gadget names are: "+strings.Join(getGadgetNames(), ", ")+". "+
 			"Example: "+
+			"{'action': 'deploy', 'action_params': {'confirm': true}}\n"+
 			"{'action': 'run', 'action_params': {'gadget_name': 'observe_dns', 'duration': 10}}\n\n"+
 			"It supports 'filter_params' (type=object) to filter the data captured by the gadget. "+
 			"Available params are: "+
@@ -61,6 +63,10 @@ func RegisterInspektorGadgetTool() mcp.Tool {
 				"chart_version": map[string]any{
 					"type":        "string",
 					"description": "The version of the Inspektor Gadget Helm chart to deploy. Only set this if user explicitly wants to deploy a specific version",
+				},
+				"confirm": map[string]any{
+					"type":        "boolean",
+					"description": "Confirmation to deploy/upgrade/undeploy Inspektor Gadget (in gadget namespace) when running server in 'readonly' mode. Only set this if user explicitly wants to perform the action in 'readonly' mode",
 				},
 			}),
 		),


### PR DESCRIPTION
This change includes a disclaimer for the user before deploy/undeploy/upgrade of Inspektor Gadget with default permissions!

cc: @julia-yin 

## Testing Done

### VSCode 

<img width="1379" height="1028" alt="Screenshot from 2025-11-17 13-04-16" src="https://github.com/user-attachments/assets/ceb1c7ba-58c6-40a9-9681-06943796a723" />


### CLI Agent 

<img width="1917" height="574" alt="Screenshot from 2025-11-17 15-52-04" src="https://github.com/user-attachments/assets/bf9001fb-34ec-4324-b51d-21e28ff626bf" />
