### PR TITLE
charts: Add permissions for Inspektor Gadget

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -31,6 +31,10 @@ rules:
 - apiGroups: ["metrics.k8s.io"]
   resources: ["pods", "nodes"]
   verbs: ["get", "list"]
+# Inspektor Gadget permissions
+- apiGroups: [""]
+  resources: ["pods/portforward"]
+  verbs: ["create"]
 {{- if or (eq .Values.app.accessLevel "readwrite") (eq .Values.app.accessLevel "admin") }}
 # Additional write permissions for readwrite and admin access levels
 - apiGroups: [""]


### PR DESCRIPTION
This change allows minimal permissions to connect to Inspektor Gadget pods for running gadgets. 