### PR TITLE
Feat: support unified kubectl tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
+	github.com/Azure/azure-api-mcp v0.0.3
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2 v2.2.1
-	github.com/Azure/mcp-kubernetes v0.0.9
+	github.com/Azure/mcp-kubernetes v0.0.10
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gopacket/gopacket v1.5.0
@@ -33,7 +34,6 @@ require (
 require (
 	code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c // indirect
 	dario.cat/mergo v1.0.1 // indirect
-	github.com/Azure/azure-api-mcp v0.0.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/Azure/mcp-kubernetes v0.0.9 h1:IRVEAnJW8Eg1e4QTBiA3xSI8/vAdGeiuoq3bKfhrM1I=
-github.com/Azure/mcp-kubernetes v0.0.9/go.mod h1:8B91zFpju5S65I93OUSg4Ek8D4JGOpy0vbbVWbO8YAY=
+github.com/Azure/mcp-kubernetes v0.0.10 h1:XP/+eeLshDzdIzrWgWarMemsO1Vz00j/Pu7s8Rw6vnA=
+github.com/Azure/mcp-kubernetes v0.0.10/go.mod h1:6YwdMr1dihmi15Wdc3sWLmCT7BDA7axhsy+oM6U3Qw4=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,9 +68,10 @@ type ConfigData struct {
 	// Telemetry service
 	TelemetryService *telemetry.Service
 
-	// UseLegacyTools controls whether to use legacy tools (az_aks_operations, az_compute_operations)
-	// or the new azure-api-mcp tool (call_az)
-	// Default is false (use azure-api-mcp)
+	// UseLegacyTools controls whether to use legacy tools or new unified tools
+	// Azure tools: true = az_aks_operations/az_compute_operations, false = call_az
+	// Kubectl tools: true = specialized tools (kubectl_resources, kubectl_workloads, etc.), false = call_kubectl
+	// Default is false (use new unified tools)
 	// This flag is provided for backward compatibility and may be removed in future versions
 	UseLegacyTools bool
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -470,8 +470,16 @@ func (s *Service) registerKubernetesComponents() {
 func (s *Service) registerKubectlComponent() {
 	logger.Debugf("Registering Core Kubernetes Component (kubectl)")
 
-	// Get kubectl tools filtered by access level
-	kubectlTools := kubectl.RegisterKubectlTools(s.cfg.AccessLevel)
+	// Use UseLegacyTools to control whether to use unified call_kubectl tool or specialized tools
+	useUnifiedTool := !s.cfg.UseLegacyTools
+	if s.cfg.UseLegacyTools {
+		logger.Debugf("Using legacy kubectl specialized tools (kubectl_resources, kubectl_workloads, etc.)")
+	} else {
+		logger.Debugf("Using unified kubectl tool (call_kubectl)")
+	}
+
+	// Get kubectl tools filtered by access level and tool type
+	kubectlTools := kubectl.RegisterKubectlTools(s.cfg.AccessLevel, useUnifiedTool)
 
 	// Create a kubectl executor
 	kubectlExecutor := kubectl.NewKubectlToolExecutor()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -136,7 +136,7 @@ func TestService(t *testing.T) {
 			service := NewService(cfg, WithAzCliProcFactory(func(timeout int) azcli.Proc { return &fakeProc{} }))
 
 			// Calculate expected kubectl tools count
-			kubectlTools := kubectl.RegisterKubectlTools(tt.accessLevel)
+			kubectlTools := kubectl.RegisterKubectlTools(tt.accessLevel, false)
 			expectedKubectlCount := len(kubectlTools)
 
 			// Add optional tools count
@@ -234,7 +234,7 @@ func TestComponentToolCounts(t *testing.T) {
 		// Test kubectl tools by access level
 		accessLevels := []string{"readonly", "readwrite", "admin"}
 		for _, level := range accessLevels {
-			kubectlTools := kubectl.RegisterKubectlTools(level)
+			kubectlTools := kubectl.RegisterKubectlTools(level, false)
 			t.Logf("Kubectl tools for %s access: %d", level, len(kubectlTools))
 
 			// Log individual kubectl tools
@@ -332,7 +332,7 @@ func TestExpectedToolsByAccessLevel(t *testing.T) {
 			// Access control is handled by operation validation, not tool registration
 
 			// Kubernetes tools
-			kubectlTools := kubectl.RegisterKubectlTools(level)
+			kubectlTools := kubectl.RegisterKubectlTools(level, false)
 			k8sToolsCount := len(kubectlTools)
 
 			t.Logf("=== Access Level: %s ===", level)


### PR DESCRIPTION
With this change, we will use the unified kubectl to replace 'kubectl_resources, kubectl_workloads, *' 