### PR TITLE
Fix: show cli output when error happens in login

### DIFF
--- a/internal/azcli/login.go
+++ b/internal/azcli/login.go
@@ -175,7 +175,7 @@ func runLoginCommand(proc Proc, cmd string, loginMethod string) error {
 		return fmt.Errorf("%s login failed: %s", loginMethod, out)
 	}
 	if err != nil {
-		return fmt.Errorf("%s login failed: %w", loginMethod, err)
+		return fmt.Errorf("%s login failed: %w; output: %s", loginMethod, err, out)
 	}
 	return nil
 }
@@ -185,16 +185,18 @@ func setSubscription(proc Proc, subscriptionID, loginMethod string) error {
 	if subscriptionID == "" {
 		return nil
 	}
-	if _, err := proc.Run(fmt.Sprintf("account set --subscription %s", subscriptionID)); err != nil {
-		return fmt.Errorf("%s login failed: %w", loginMethod, err)
+	out, err := proc.Run(fmt.Sprintf("account set --subscription %s", subscriptionID))
+	if err != nil {
+		return fmt.Errorf("%s set subscription failed: %w; output: %s", loginMethod, err, out)
 	}
 	return nil
 }
 
 // Checks that account info is returned after a login attempt.
 func showAccount(proc Proc, loginMethod string) error {
-	if _, err := proc.Run("account show --query id -o tsv"); err != nil {
-		return fmt.Errorf("%s login failed: %w", loginMethod, err)
+	out, err := proc.Run("account show --query id -o tsv")
+	if err != nil {
+		return fmt.Errorf("%s account verification failed: %w; output: %s", loginMethod, err, out)
 	}
 	return nil
 }

--- a/internal/azcli/login_test.go
+++ b/internal/azcli/login_test.go
@@ -145,7 +145,7 @@ func TestEnsureAzCliLogin_SubscriptionSetFailure(t *testing.T) {
 	}}
 
 	_, err := EnsureAzCliLoginWithProc(p, cfg)
-	if err == nil || !strings.Contains(err.Error(), "service principal login failed") {
+	if err == nil || !strings.Contains(err.Error(), "service principal set subscription failed") {
 		t.Fatalf("expected subscription set failure wrapped in service principal context, got %v", err)
 	}
 }
@@ -165,7 +165,7 @@ func TestEnsureAzCliLogin_ReprobeFailure(t *testing.T) {
 	}}
 
 	_, err := EnsureAzCliLoginWithProc(p, cfg)
-	if err == nil || !strings.Contains(err.Error(), "service principal login failed") {
+	if err == nil || !strings.Contains(err.Error(), "service principal account verification failed") {
 		t.Fatalf("expected reprobe failure wrapped in service principal context, got %v", err)
 	}
 }


### PR DESCRIPTION
Without cli output log, it is hard to know why it failed to login. this pr is enrich the output.