### PR TITLE
docs: add GitHub Copilot CLI to supported clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ For a persistent configuration that works across all your VS Code workspaces, ad
 <details>
 <summary>Docker and Custom Client Installation</summary>
 
-For other MCP-compatible AI clients like [Claude Desktop](https://claude.ai/), configure the server in your MCP configuration:
+For other MCP-compatible AI clients like [Claude Desktop](https://claude.ai/) or [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli), configure the server in your MCP configuration:
 
 ```json
 {


### PR DESCRIPTION
Adds GitHub Copilot CLI alongside Claude Desktop in the "Docker and Custom Client Installation" section.

## Changes
- Added GitHub Copilot CLI with link to official documentation

This is a minimal documentation update to help Copilot CLI users discover that the configuration example applies to their tool as well.