### PR TITLE
Feat: merge detector tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,20 +224,54 @@ CRD operations.
 <details>
 <summary>Diagnostic Detectors</summary>
 
-**Tool:** `list_detectors`
+**Tool:** `aks_detector`
 
-- List all available AKS cluster detectors
+Unified tool for executing AKS diagnostic detector operations.
 
-**Tool:** `run_detector`
+**Available Operations:**
 
-- Run a specific AKS diagnostic detector
+- `list`: List all available AKS cluster detectors
+- `run`: Run a specific AKS diagnostic detector
+- `run_by_category`: Run all detectors in a specific category
 
-**Tool:** `run_detectors_by_category`
+**Parameters:**
 
-- Run all detectors in a specific category
-- **Categories**: Best Practices, Cluster and Control Plane Availability and
-  Performance, Connectivity Issues, Create/Upgrade/Delete and Scale,
-  Deprecations, Identity and Security, Node Health, Storage
+- `operation` (required): Operation to perform (`list`, `run`, or `run_by_category`)
+- `aks_resource_id` (required): AKS cluster resource ID
+- `detector_name` (required for `run` operation): Name of the detector to run
+- `category` (required for `run_by_category` operation): Detector category
+- `start_time` (required for `run` and `run_by_category` operations): Start time in UTC ISO format (within last 30 days)
+- `end_time` (required for `run` and `run_by_category` operations): End time in UTC ISO format (within last 30 days, max 24h from start)
+
+**Available Categories:**
+
+- Best Practices
+- Cluster and Control Plane Availability and Performance
+- Connectivity Issues
+- Create, Upgrade, Delete and Scale
+- Deprecations
+- Identity and Security
+- Node Health
+- Storage
+
+**Example Usage:**
+
+```json
+{
+  "operation": "list",
+  "aks_resource_id": "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.ContainerService/managedClusters/xxx"
+}
+```
+
+```json
+{
+  "operation": "run",
+  "aks_resource_id": "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.ContainerService/managedClusters/xxx",
+  "detector_name": "node-health-detector",
+  "start_time": "2025-01-15T10:00:00Z",
+  "end_time": "2025-01-15T12:00:00Z"
+}
+```
 
 </details>
 

--- a/internal/components/detectors/registry.go
+++ b/internal/components/detectors/registry.go
@@ -6,68 +6,32 @@ import (
 
 // Detector-related tool registrations
 
-// RegisterListDetectorsTool registers the list_detectors MCP tool
-func RegisterListDetectorsTool() mcp.Tool {
+// RegisterAksDetectorTool registers the unified aks_detector MCP tool
+func RegisterAksDetectorTool() mcp.Tool {
 	return mcp.NewTool(
-		"list_detectors",
-		mcp.WithDescription("List all available AKS cluster detectors"),
-		mcp.WithTitleAnnotation("List Detectors"),
+		"aks_detector",
+		mcp.WithDescription("Execute AKS detector operations (list detectors, run detector, or run detectors by category)"),
+		mcp.WithTitleAnnotation("Call Detector"),
 		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithString("cluster_resource_id",
-			mcp.Description("AKS cluster resource ID"),
+		mcp.WithString("operation",
+			mcp.Description("Operation to perform: 'list' (list all detectors), 'run' (run single detector), 'run_by_category' (run all detectors in category)"),
 			mcp.Required(),
 		),
-	)
-}
-
-// RegisterRunDetectorTool registers the run_detector MCP tool
-func RegisterRunDetectorTool() mcp.Tool {
-	return mcp.NewTool(
-		"run_detector",
-		mcp.WithDescription("Run a specific AKS detector"),
-		mcp.WithTitleAnnotation("Run Detector"),
-		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithString("cluster_resource_id",
+		mcp.WithString("aks_resource_id",
 			mcp.Description("AKS cluster resource ID"),
 			mcp.Required(),
 		),
 		mcp.WithString("detector_name",
-			mcp.Description("Name of the detector to run"),
-			mcp.Required(),
-		),
-		mcp.WithString("start_time",
-			mcp.Description("Start time in UTC ISO format (within last 30 days). Example: 2025-07-11T10:55:13Z"),
-			mcp.Required(),
-		),
-		mcp.WithString("end_time",
-			mcp.Description("End time in UTC ISO format (within last 30 days, max 24h from start). Example: 2025-07-11T14:55:13Z"),
-			mcp.Required(),
-		),
-	)
-}
-
-// RegisterRunDetectorsByCategoryTool registers the run_detectors_by_category MCP tool
-func RegisterRunDetectorsByCategoryTool() mcp.Tool {
-	return mcp.NewTool(
-		"run_detectors_by_category",
-		mcp.WithDescription("Run all detectors in a specific category"),
-		mcp.WithTitleAnnotation("Run Detectors By Category"),
-		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithString("cluster_resource_id",
-			mcp.Description("AKS cluster resource ID"),
-			mcp.Required(),
+			mcp.Description("Name of the detector to run (required for 'run' operation)"),
 		),
 		mcp.WithString("category",
-			mcp.Description("Detector category to run (Best Practices, Cluster and Control Plane Availability and Performance, Connectivity Issues, Create/Upgrade/Delete and Scale, Deprecations, Identity and Security, Node Health, Storage)"),
-			mcp.Required(),
+			mcp.Description("Detector category (required for 'run_by_category' operation). Valid values: Best Practices, Cluster and Control Plane Availability and Performance, Connectivity Issues, Create/Upgrade/Delete and Scale, Deprecations, Identity and Security, Node Health, Storage"),
 		),
 		mcp.WithString("start_time",
-			mcp.Description("Start time in UTC ISO format (within last 30 days). Example: 2025-07-11T10:55:13Z"),
-			mcp.Required(),
+			mcp.Description("Start time in UTC ISO format (required for 'run' and 'run_by_category' operations, within last 30 days). Example: 2025-07-11T10:55:13Z"),
 		),
 		mcp.WithString("end_time",
-			mcp.Description("End time in UTC ISO format (within last 30 days, max 24h from start). Example: 2025-07-11T14:55:13Z"),
-			mcp.Required(),
+			mcp.Description("End time in UTC ISO format (required for 'run' and 'run_by_category' operations, within last 30 days, max 24h from start). Example: 2025-07-11T14:55:13Z"),
 		),
 	)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -648,20 +648,10 @@ func (s *Service) registerComputeComponent() {
 func (s *Service) registerDetectorComponent() {
 	logger.Debugf("Registering Detector Resources Component")
 
-	// Register list detectors tool
-	logger.Debugf("Registering detector tool: list_detectors")
-	listTool := detectors.RegisterListDetectorsTool()
-	s.mcpServer.AddTool(listTool, tools.CreateResourceHandler(detectors.GetListDetectorsHandler(s.azClient, s.cfg), s.cfg))
-
-	// Register run detector tool
-	logger.Debugf("Registering detector tool: run_detector")
-	runTool := detectors.RegisterRunDetectorTool()
-	s.mcpServer.AddTool(runTool, tools.CreateResourceHandler(detectors.GetRunDetectorHandler(s.azClient, s.cfg), s.cfg))
-
-	// Register run detectors by category tool
-	logger.Debugf("Registering detector tool: run_detectors_by_category")
-	categoryTool := detectors.RegisterRunDetectorsByCategoryTool()
-	s.mcpServer.AddTool(categoryTool, tools.CreateResourceHandler(detectors.GetRunDetectorsByCategoryHandler(s.azClient, s.cfg), s.cfg))
+	// Register unified detector tool
+	logger.Debugf("Registering detector tool: aks_detector")
+	aksDetectorTool := detectors.RegisterAksDetectorTool()
+	s.mcpServer.AddTool(aksDetectorTool, tools.CreateResourceHandler(detectors.GetAksDetectorHandler(s.azClient, s.cfg), s.cfg))
 }
 
 // registerHelmComponent registers helm tools if enabled


### PR DESCRIPTION
This pull request refactors and unifies the AKS detector handler logic and tool registration. Instead of having separate tools and handlers for listing detectors, running a detector, and running detectors by category, everything is now consolidated under a single `aks_detector` tool and handler. This change simplifies the codebase, reduces duplication, and makes it easier to maintain and extend.

Key changes include:

**Unification of Detector Tools and Handlers**
- Replaced the three separate tools (`list_detectors`, `run_detector`, and `run_detectors_by_category`) with a single `aks_detector` tool that supports an `operation` parameter to specify which action to perform. The tool registration and handler logic have been updated accordingly. 

**Handler Refactoring**
- Introduced a unified handler function, `HandleAksDetector`, that routes requests to operation-specific internal functions (`handleListOperation`, `handleRunOperation`, `handleRunByCategoryOperation`) based on the `operation` parameter. This replaces the previous pattern of separate handler functions for each operation.

**Parameter and Error Handling Improvements**
- Standardized parameter names to `aks_resource_id` throughout (replacing `cluster_resource_id`). Improved error messages and validation for required parameters in each operation.

**Tool Registration and Documentation**
- Updated the tool registration to reflect the unified interface, including improved descriptions and parameter documentation for the new `aks_detector` tool.
