### PR TITLE
fix: block @file argument injection to prevent arbitrary file reads

### DIFF
--- a/internal/components/azapi/handler.go
+++ b/internal/components/azapi/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/aks-mcp/internal/config"
 	"github.com/Azure/aks-mcp/internal/logger"
 	"github.com/Azure/azure-api-mcp/pkg/azcli"
+	"github.com/google/shlex"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -34,11 +35,25 @@ var azureHostPattern = regexp.MustCompile(`(?i)(^|\.)(azure\.com|azure\.cn|azure
 
 // validateAzCommand provides defense-in-depth validation for az CLI commands.
 // It blocks "az rest" commands where --url points to a non-Azure host,
-// preventing token exfiltration attacks.
+// preventing token exfiltration attacks. It also blocks @file arguments across
+// all command types to prevent arbitrary local file reads.
 func validateAzCommand(cliCommand string) error {
+	// Block az CLI @file expansion: any token starting with @ triggers file content
+	// substitution in az CLI pre-processing, enabling arbitrary file reads.
+	{
+		tokens, err := shlex.Split(cliCommand)
+		if err == nil {
+			for _, token := range tokens {
+				if strings.HasPrefix(token, "@") {
+					return fmt.Errorf("command contains @file argument which would cause az CLI to read local files; this is blocked as a security measure")
+				}
+			}
+		}
+	}
+
 	tokens := strings.Fields(cliCommand)
 
-	// Only inspect "az rest" commands
+	// Only inspect "az rest" commands for URL validation
 	if len(tokens) < 2 || tokens[0] != "az" || tokens[1] != "rest" {
 		return nil
 	}

--- a/internal/components/azapi/handler_test.go
+++ b/internal/components/azapi/handler_test.go
@@ -447,6 +447,26 @@ func TestValidateAzCommand(t *testing.T) {
 			input:   "az group list",
 			wantErr: false,
 		},
+		{
+			name:    "at file injection via name arg - rejected",
+			input:   "az aks show --name @/etc/passwd --resource-group rg",
+			wantErr: true,
+		},
+		{
+			name:    "at file absolute path - rejected",
+			input:   "az resource list @/tmp/params.json",
+			wantErr: true,
+		},
+		{
+			name:    "at file relative path - rejected",
+			input:   "az aks create @../evil.json",
+			wantErr: true,
+		},
+		{
+			name:    "email in flag value mid-token - allowed",
+			input:   "az aks show --contact admin@corp.com --name myCluster --resource-group rg",
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/security/validator.go
+++ b/internal/security/validator.go
@@ -2,6 +2,8 @@ package security
 
 import (
 	"strings"
+
+	"github.com/google/shlex"
 )
 
 // Command type constants
@@ -192,6 +194,21 @@ func (v *Validator) validateCommandInjection(command string) error {
 				}
 				// Skip the next '<' since we've verified it's part of '<<'
 				i++
+			}
+		}
+	}
+
+	// Block az CLI @file expansion: any argument token starting with @ causes az CLI
+	// to read that path and substitute its content, enabling arbitrary file reads.
+	// We check at token level (not substring) so that @ embedded mid-value
+	// (e.g. user@example.com) is not blocked.
+	{
+		tokens, err := shlex.Split(command)
+		if err == nil {
+			for _, token := range tokens {
+				if strings.HasPrefix(token, "@") {
+					return &ValidationError{Message: "Error: Command contains potentially dangerous characters or patterns"}
+				}
 			}
 		}
 	}

--- a/internal/security/validator_test.go
+++ b/internal/security/validator_test.go
@@ -725,6 +725,11 @@ func TestValidateCommandInjection_IsolatedFunction(t *testing.T) {
 		{"newline", "az aks show\necho test", true},
 		{"carriage_return", "az aks show\recho test", true},
 		{"variable_substitution", "az aks show ${var}", true},
+		{"at_file_injection_name", "az aks show --name @/etc/passwd --resource-group rg", true},
+		{"at_file_injection_resource_group", "az aks show --name myCluster --resource-group @/etc/shadow", true},
+		{"at_file_absolute_path", "az aks create @/tmp/malicious.json", true},
+		{"at_file_relative_path", "az aks create @../secrets.json", true},
+		{"email_in_flag_value_allowed", "az aks show --contact user@example.com --name myCluster --resource-group rg", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Blocks az CLI `@file` argument expansion in both `az_aks_operations` and `call_az` tool paths
- Any command token starting with `@` is now rejected by the validator (e.g. `--name @/etc/passwd`)
- Uses `shlex` token-level detection so legitimate values like `user@example.com` (where `@` is mid-token) are not affected

## Background

Azure CLI's `_expand_file_prefixed_files` pre-processing reads any argument starting with `@` as a local file path and substitutes its contents before the command is dispatched. The validator blocked shell metacharacters (`;`, `|`, `&`, etc.) but not `@`, allowing an attacker with MCP tool access (or via prompt injection) to read arbitrary files on the server and leak their contents via API error messages.

## Changes

- `internal/security/validator.go`: added shlex-based `@`-token check at the end of `validateCommandInjection` (covers `az_aks_operations` tool)
- `internal/components/azapi/handler.go`: added same check at the start of `validateAzCommand` (covers `call_az` tool)
- Tests added for both code paths, including edge cases for `user@example.com` style values

## Severity

Low (defense-in-depth). No privilege escalation — the caller can only read files they already have OS permission to read, using their own credentials. The realistic attack vector is indirect prompt injection. Does not warrant a CVE.

## Test plan

- [ ] `go test ./internal/security/...` — new `at_file_*` test cases pass
- [ ] `go test ./internal/components/azapi/...` — new `TestValidateAzCommand` cases pass
- [ ] `go test -race ./...` — all 27 packages pass, no race conditions
- [ ] `make build` — binary builds successfully