### PR TITLE
fix: move az fleet get-credentials to admin-only access level

### DIFF
--- a/internal/azcli/fleet_executor.go
+++ b/internal/azcli/fleet_executor.go
@@ -115,8 +115,16 @@ func (e *FleetExecutor) validateCombination(operation, resource string) error {
 
 // checkAccessLevel ensures the operation is allowed for the current access level
 func (e *FleetExecutor) checkAccessLevel(operation, resource string, accessLevel string) error {
+	// get-credentials writes kubeconfig to disk — require admin, consistent with az aks get-credentials
+	if operation == "get-credentials" {
+		if accessLevel != "admin" {
+			return fmt.Errorf("operation 'get-credentials' requires admin access level, current level is %s", accessLevel)
+		}
+		return nil
+	}
+
 	// Read-only operations are allowed for all access levels
-	readOnlyOps := []string{"list", "show", "get", "get-credentials"}
+	readOnlyOps := []string{"list", "show", "get"}
 	for _, op := range readOnlyOps {
 		if operation == op {
 			return nil

--- a/internal/azcli/fleet_executor_test.go
+++ b/internal/azcli/fleet_executor_test.go
@@ -123,6 +123,30 @@ func TestFleetExecutor_CheckAccessLevel(t *testing.T) {
 			accessLevel: "admin",
 			wantErr:     false,
 		},
+		// get-credentials must require admin, consistent with az aks get-credentials
+		{
+			name:        "readonly cannot get-credentials",
+			operation:   "get-credentials",
+			resource:    "fleet",
+			accessLevel: "readonly",
+			wantErr:     true,
+			errMsg:      "requires admin access level",
+		},
+		{
+			name:        "readwrite cannot get-credentials",
+			operation:   "get-credentials",
+			resource:    "fleet",
+			accessLevel: "readwrite",
+			wantErr:     true,
+			errMsg:      "requires admin access level",
+		},
+		{
+			name:        "admin can get-credentials",
+			operation:   "get-credentials",
+			resource:    "fleet",
+			accessLevel: "admin",
+			wantErr:     false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- `az fleet get-credentials` was incorrectly classified as a read-only operation in `checkAccessLevel()`, allowing readonly-scoped MCP sessions to obtain kubeconfig credentials for Azure Fleet hub clusters
- Moved `get-credentials` to require admin access level, consistent with the existing admin-only restriction on `az aks get-credentials`
- Added test cases verifying readonly and readwrite access levels are rejected

## Security Impact

Low severity (defense-in-depth). The operation only succeeds for clusters the authenticated user already has Azure RBAC access to — no unauthorized access is granted. The concern is the design inconsistency and the persistent side effect of kubeconfig being written to disk.

Related MSRC reports: VULN-181026, VULN-181027