### PR TITLE
fix(oauth): support external URL override for TLS-terminating proxy d…

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
             - "--oauth-cors-origins"
             - {{ $corsOrigins | quote }}
             {{- end }}
+            {{- if .Values.oauth.externalURL }}
+            - "--oauth-external-url"
+            - {{ .Values.oauth.externalURL | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.app.logLevel }}
             - "--log-level"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,6 +67,10 @@ oauth:
   redirectURIs: []
   # Custom CORS origins (auto-generated if empty)
   corsOrigins: []
+  # External base URL of the server (e.g. https://aks-mcp.example.com).
+  # Required when the server is behind a TLS-terminating reverse proxy so that
+  # OAuth metadata endpoints return https:// URLs instead of http://.
+  externalURL: ""
 
 # Application configuration
 config:

--- a/internal/auth/oauth/endpoints.go
+++ b/internal/auth/oauth/endpoints.go
@@ -1,17 +1,15 @@
 package oauth
 
 import (
-	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/Azure/aks-mcp/internal/auth"
 	"github.com/Azure/aks-mcp/internal/config"
 	"github.com/Azure/aks-mcp/internal/logger"
 )
@@ -43,15 +41,18 @@ func validateAzureADURL(tokenURL string) error {
 
 // EndpointManager manages OAuth-related HTTP endpoints
 type EndpointManager struct {
-	provider *AzureOAuthProvider
-	cfg      *config.ConfigData
+	provider      *AzureOAuthProvider
+	cfg           *config.ConfigData
+	mu            sync.Mutex
+	pendingStates map[string]string // state → original client redirect_uri
 }
 
 // NewEndpointManager creates a new OAuth endpoint manager
 func NewEndpointManager(provider *AzureOAuthProvider, cfg *config.ConfigData) *EndpointManager {
 	return &EndpointManager{
-		provider: provider,
-		cfg:      cfg,
+		provider:      provider,
+		cfg:           cfg,
+		pendingStates: make(map[string]string),
 	}
 }
 
@@ -547,6 +548,38 @@ func (em *EndpointManager) authorizationProxyHandler() http.HandlerFunc {
 		query.Set("scope", finalScopeString)
 		logger.Debugf("OAuth DEBUG: Setting final scope for Azure AD: %s", finalScopeString)
 
+		// Store state → client redirect_uri so the callback handler can relay the
+		// authorization code back to the MCP client after Azure AD redirects to our
+		// /oauth/callback endpoint. This is client-agnostic: any OAuth 2.1 client
+		// (Claude.ai, VS Code, MCP Inspector, etc.) works as long as its redirect_uri
+		// is in the configured allowed list.
+		state := query.Get("state")
+		if state != "" {
+			em.mu.Lock()
+			em.pendingStates[state] = redirectURI
+			em.mu.Unlock()
+		}
+
+		// Replace redirect_uri with the server's own callback URL. Azure AD must
+		// redirect to a URI registered in the app registration (our server), not
+		// directly to the MCP client.
+		var serverCallbackURL string
+		if em.provider.config.ExternalURL != "" {
+			serverCallbackURL = em.provider.config.ExternalURL + "/oauth/callback"
+		} else {
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
+			host := r.Host
+			if host == "" {
+				host = r.URL.Host
+			}
+			serverCallbackURL = fmt.Sprintf("%s://%s/oauth/callback", scheme, host)
+		}
+		query.Set("redirect_uri", serverCallbackURL)
+		logger.Debugf("OAuth DEBUG: Using server callback URL for Azure AD: %s", serverCallbackURL)
+
 		// Build the Azure AD authorization URL
 		azureAuthURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/authorize", em.cfg.OAuthConfig.TenantID)
 
@@ -559,7 +592,12 @@ func (em *EndpointManager) authorizationProxyHandler() http.HandlerFunc {
 	}
 }
 
-// callbackHandler handles OAuth 2.0 Authorization Code flow callback
+// callbackHandler handles OAuth 2.0 Authorization Code flow callback.
+//
+// The server acts as a proxy: Azure AD redirects here with the authorization
+// code, and we relay the code back to the original MCP client redirect_uri
+// that was stored during /authorize. The MCP client then exchanges the code
+// directly with Azure AD (using its PKCE verifier) via /oauth2/v2.0/token.
 func (em *EndpointManager) callbackHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger.Debugf("OAuth DEBUG: Received callback request: %s %s", r.Method, r.URL.Path)
@@ -579,66 +617,49 @@ func (em *EndpointManager) callbackHandler() http.HandlerFunc {
 			return
 		}
 
-		// Parse query parameters
 		query := r.URL.Query()
+		code := query.Get("code")
+		state := query.Get("state")
+		errParam := query.Get("error")
+		errDesc := query.Get("error_description")
 
-		// Check for error response from authorization server
-		if authError := query.Get("error"); authError != "" {
-			errorDesc := query.Get("error_description")
-			logger.Errorf("OAuth ERROR: Authorization server returned error: %s - %s", authError, errorDesc)
-			em.writeCallbackErrorResponse(w, fmt.Sprintf("Authorization failed: %s - %s", authError, errorDesc))
+		// Look up and consume the client redirect_uri stored during /authorize.
+		em.mu.Lock()
+		redirectURI, ok := em.pendingStates[state]
+		delete(em.pendingStates, state)
+		em.mu.Unlock()
+
+		if !ok || redirectURI == "" {
+			logger.Errorf("OAuth ERROR: No pending state found for state=%q", state)
+			http.Error(w, "invalid or expired state", http.StatusBadRequest)
 			return
 		}
 
-		// Get authorization code
-		code := query.Get("code")
+		// Forward any upstream error from Azure AD back to the MCP client.
+		if errParam != "" {
+			logger.Errorf("OAuth ERROR: Authorization server returned error: %s - %s", errParam, errDesc)
+			target := redirectURI +
+				"?error=" + url.QueryEscape(errParam) +
+				"&error_description=" + url.QueryEscape(errDesc) +
+				"&state=" + url.QueryEscape(state)
+			http.Redirect(w, r, target, http.StatusFound)
+			return
+		}
+
 		if code == "" {
 			logger.Errorf("OAuth ERROR: Missing authorization code in callback")
-			em.writeCallbackErrorResponse(w, "Missing authorization code")
+			http.Error(w, "missing code parameter", http.StatusBadRequest)
 			return
 		}
 
-		// Get state parameter for CSRF protection
-		state := query.Get("state")
-		if state == "" {
-			logger.Errorf("OAuth ERROR: Missing state parameter in callback")
-			em.writeCallbackErrorResponse(w, "Missing state parameter")
-			return
-		}
+		logger.Debugf("OAuth DEBUG: Relaying authorization code to client redirect_uri, state: %s", state)
 
-		logger.Debugf("OAuth DEBUG: Callback parameters validated - has_code: true, state: %s", state)
-
-		// Validate redirect URI for security - construct expected URI and validate it
-		expectedRedirectURI := fmt.Sprintf("http://%s:%d/oauth/callback", em.cfg.Host, em.cfg.Port)
-		if err := em.validateRedirectURI(expectedRedirectURI); err != nil {
-			logger.Errorf("OAuth ERROR: Redirect URI validation failed: %v", err)
-			em.writeCallbackErrorResponse(w, "Invalid redirect URI")
-			return
-		}
-
-		// Exchange authorization code for access token
-		tokenResponse, err := em.exchangeCodeForToken(code, state)
-		if err != nil {
-			logger.Errorf("OAuth ERROR: Failed to exchange authorization code for token: %v", err)
-			em.writeCallbackErrorResponse(w, fmt.Sprintf("Failed to exchange code for token: %v", err))
-			return
-		}
-
-		// Skip token validation in callback - validation happens during MCP requests
-		// Create minimal token info for callback success page
-		tokenInfo := &auth.TokenInfo{
-			AccessToken: tokenResponse.AccessToken,
-			TokenType:   "Bearer",
-			ExpiresAt:   time.Now().Add(time.Hour),         // Default 1 hour expiration
-			Scope:       em.cfg.OAuthConfig.RequiredScopes, // Use configured scopes
-			Subject:     "authenticated_user",              // Placeholder
-			Audience:    []string{fmt.Sprintf("https://sts.windows.net/%s/", em.cfg.OAuthConfig.TenantID)},
-			Issuer:      fmt.Sprintf("https://sts.windows.net/%s/", em.cfg.OAuthConfig.TenantID),
-			Claims:      make(map[string]interface{}),
-		}
-
-		// Return success response with token information
-		em.writeCallbackSuccessResponse(w, tokenResponse, tokenInfo)
+		// Relay the authorization code to the MCP client. The client holds the
+		// PKCE code_verifier and will exchange the code directly with Azure AD.
+		target := redirectURI +
+			"?code=" + url.QueryEscape(code) +
+			"&state=" + url.QueryEscape(state)
+		http.Redirect(w, r, target, http.StatusFound)
 	}
 }
 
@@ -649,172 +670,6 @@ type TokenResponse struct {
 	ExpiresIn    int    `json:"expires_in"`
 	RefreshToken string `json:"refresh_token,omitempty"` // #nosec G117 -- Standard OAuth2 field name
 	Scope        string `json:"scope,omitempty"`
-}
-
-// exchangeCodeForToken exchanges authorization code for access token
-func (em *EndpointManager) exchangeCodeForToken(code, state string) (*TokenResponse, error) {
-	// Prepare token exchange request
-	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", em.cfg.OAuthConfig.TenantID)
-
-	// Validate URL for security
-	if err := validateAzureADURL(tokenURL); err != nil {
-		return nil, fmt.Errorf("invalid token URL: %w", err)
-	}
-
-	// Use default callback redirect URI for token exchange
-	redirectURI := fmt.Sprintf("http://%s:%d/oauth/callback", em.cfg.Host, em.cfg.Port)
-
-	// Prepare form data
-	data := url.Values{}
-	data.Set("grant_type", "authorization_code")
-	data.Set("client_id", em.cfg.OAuthConfig.ClientID)
-	data.Set("code", code)
-	data.Set("redirect_uri", redirectURI)
-	data.Set("scope", strings.Join(em.cfg.OAuthConfig.RequiredScopes, " "))
-
-	// Note: Azure AD v2.0 doesn't support the 'resource' parameter in token requests
-	// It uses scope-based resource identification instead
-	// For MCP compliance, we handle resource binding through audience validation
-
-	// Make token exchange request
-	resp, err := http.PostForm(tokenURL, data) // #nosec G107,G704 -- URL is validated above
-	if err != nil {
-		return nil, fmt.Errorf("token exchange request failed: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			logger.Errorf("Failed to close response body: %v", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	// Parse token response
-	var tokenResponse TokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
-		return nil, fmt.Errorf("failed to parse token response: %w", err)
-	}
-
-	return &tokenResponse, nil
-}
-
-// writeCallbackErrorResponse writes an error response for callback
-func (em *EndpointManager) writeCallbackErrorResponse(w http.ResponseWriter, message string) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.WriteHeader(http.StatusBadRequest)
-
-	html := fmt.Sprintf(`
-<!DOCTYPE html>
-<html>
-<head>
-    <title>OAuth Authentication Error</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 40px; }
-        .error { background-color: #fee; border: 1px solid #fcc; padding: 20px; border-radius: 5px; }
-        .error h1 { color: #c33; margin-top: 0; }
-    </style>
-</head>
-<body>
-    <div class="error">
-        <h1>Authentication Error</h1>
-        <p>%s</p>
-        <p>Please try again or contact your administrator.</p>
-    </div>
-</body>
-</html>`, message)
-
-	if _, err := w.Write([]byte(html)); err != nil {
-		logger.Errorf("Failed to write error response: %v", err)
-	}
-}
-
-// writeCallbackSuccessResponse writes a success response for callback
-func (em *EndpointManager) writeCallbackSuccessResponse(w http.ResponseWriter, tokenResponse *TokenResponse, tokenInfo *auth.TokenInfo) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-
-	// Generate a secure session token for the client to use
-	_, err := em.generateSessionToken()
-	if err != nil {
-		em.writeCallbackErrorResponse(w, "Failed to generate session token")
-		return
-	}
-
-	html := fmt.Sprintf(`
-<!DOCTYPE html>
-<html>
-<head>
-    <title>OAuth Authentication Success</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 40px; }
-        .success { background-color: #efe; border: 1px solid #cfc; padding: 20px; border-radius: 5px; }
-        .success h1 { color: #3c3; margin-top: 0; }
-        .token-info { background-color: #f9f9f9; border: 1px solid #ddd; padding: 15px; margin: 15px 0; border-radius: 3px; }
-        .token { font-family: monospace; word-break: break-all; background-color: #f5f5f5; padding: 10px; border-radius: 3px; }
-        .copy-btn { background-color: #007cba; color: white; border: none; padding: 5px 10px; border-radius: 3px; cursor: pointer; }
-    </style>
-</head>
-<body>
-    <div class="success">
-        <h1>Authentication Successful</h1>
-        <p>You have been successfully authenticated with Azure AD.</p>
-        
-        <div class="token-info">
-            <h3>Access Token (use as Bearer token):</h3>
-            <div class="token" id="accessToken">%s</div>
-            <button class="copy-btn" onclick="copyToClipboard('accessToken')">Copy Token</button>
-        </div>
-        
-        <div class="token-info">
-            <h3>Token Information:</h3>
-            <ul>
-                <li><strong>Subject:</strong> %s</li>
-                <li><strong>Audience:</strong> %s</li>
-                <li><strong>Scope:</strong> %s</li>
-                <li><strong>Expires:</strong> %s</li>
-            </ul>
-        </div>
-        
-        <div class="token-info">
-            <h3>For MCP Client Usage:</h3>
-            <p>Use this token in the Authorization header:</p>
-            <div class="token">Authorization: Bearer %s</div>
-            <button class="copy-btn" onclick="copyToClipboard('bearerToken')">Copy Authorization Header</button>
-        </div>
-    </div>
-    
-    <script>
-        function copyToClipboard(elementId) {
-            const element = document.getElementById(elementId);
-            const text = elementId === 'bearerToken' ? 'Bearer ' + element.textContent : element.textContent;
-            navigator.clipboard.writeText(text).then(function() {
-                alert('Copied to clipboard!');
-            });
-        }
-        
-        // Set hidden bearer token element
-        const bearerTokenElement = document.createElement('div');
-        bearerTokenElement.id = 'bearerToken';
-        bearerTokenElement.style.display = 'none';
-        bearerTokenElement.textContent = '%s';
-        document.body.appendChild(bearerTokenElement);
-    </script>
-</body>
-</html>`,
-		tokenResponse.AccessToken,
-		tokenInfo.Subject,
-		strings.Join(tokenInfo.Audience, ", "),
-		strings.Join(tokenInfo.Scope, ", "),
-		tokenInfo.ExpiresAt.Format("2006-01-02 15:04:05 UTC"),
-		tokenResponse.AccessToken,
-		tokenResponse.AccessToken)
-
-	if _, err := w.Write([]byte(html)); err != nil {
-		logger.Errorf("Failed to write success response: %v", err)
-	}
 }
 
 // isValidClientID validates if a client ID is acceptable
@@ -828,15 +683,6 @@ func (em *EndpointManager) isValidClientID(clientID string) bool {
 	// But for Azure AD integration, we primarily use the configured client ID
 
 	return false
-}
-
-// generateSessionToken generates a secure random session token
-func (em *EndpointManager) generateSessionToken() (string, error) {
-	bytes := make([]byte, 32)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	return base64.URLEncoding.EncodeToString(bytes), nil
 }
 
 // tokenHandler handles OAuth 2.0 token endpoint requests (Authorization Code exchange)

--- a/internal/auth/oauth/endpoints.go
+++ b/internal/auth/oauth/endpoints.go
@@ -765,6 +765,27 @@ func (em *EndpointManager) tokenHandler() http.HandlerFunc {
 			return
 		}
 
+		// Azure AD requires the redirect_uri in the token request to exactly match
+		// the one used in the authorize request (RFC 6749 §4.1.3). The authorize
+		// handler substitutes the server's own callback URL before forwarding to
+		// Azure AD, so the token request must use the same URL. The client's
+		// redirect_uri has already been validated above.
+		var serverCallbackURL string
+		if em.provider.config.ExternalURL != "" {
+			serverCallbackURL = em.provider.config.ExternalURL + "/oauth/callback"
+		} else {
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
+			host := r.Host
+			if host == "" {
+				host = r.URL.Host
+			}
+			serverCallbackURL = fmt.Sprintf("%s://%s/oauth/callback", scheme, host)
+		}
+		logger.Debugf("OAuth DEBUG: Using server callback URL for token exchange: %s", serverCallbackURL)
+
 		// Extract scope from the token request (MCP client should send the same scope)
 		requestedScope := r.FormValue("scope")
 		if requestedScope == "" {
@@ -775,7 +796,7 @@ func (em *EndpointManager) tokenHandler() http.HandlerFunc {
 		logger.Debugf("OAuth DEBUG: Exchanging authorization code for access token with Azure AD, scope: %s", requestedScope)
 
 		// Exchange authorization code for access token with Azure AD
-		tokenResponse, err := em.exchangeCodeForTokenDirect(code, redirectURI, codeVerifier, requestedScope)
+		tokenResponse, err := em.exchangeCodeForTokenDirect(code, serverCallbackURL, codeVerifier, requestedScope)
 		if err != nil {
 			logger.Errorf("OAuth ERROR: Token exchange with Azure AD failed: %v", err)
 			em.writeErrorResponse(w, "invalid_grant", fmt.Sprintf("Authorization code exchange failed: %v", err), http.StatusBadRequest)

--- a/internal/auth/oauth/endpoints.go
+++ b/internal/auth/oauth/endpoints.go
@@ -144,19 +144,25 @@ func (em *EndpointManager) authServerMetadataProxyHandler() http.HandlerFunc {
 		// Get metadata from Azure AD
 		provider := em.provider
 
-		// Build server URL based on the request
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
-		}
+		// Build server URL: prefer ExternalURL (needed behind TLS-terminating proxies
+		// where r.TLS is always nil), otherwise derive from the request.
+		var serverURL string
+		if em.provider.config.ExternalURL != "" {
+			serverURL = em.provider.config.ExternalURL
+		} else {
+			// Build server URL based on the request
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
 
-		// Use the Host header from the request
-		host := r.Host
-		if host == "" {
-			host = r.URL.Host
+			// Use the Host header from the request
+			host := r.Host
+			if host == "" {
+				host = r.URL.Host
+			}
+			serverURL = fmt.Sprintf("%s://%s", scheme, host)
 		}
-
-		serverURL := fmt.Sprintf("%s://%s", scheme, host)
 
 		metadata, err := provider.GetAuthorizationServerMetadata(serverURL)
 		if err != nil {
@@ -392,18 +398,6 @@ func (em *EndpointManager) protectedResourceMetadataHandler() http.HandlerFunc {
 			return
 		}
 
-		// Build resource URL based on the request
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
-		}
-
-		// Use the Host header from the request
-		host := r.Host
-		if host == "" {
-			host = r.URL.Host
-		}
-
 		// Build the resource URL with correct MCP endpoint path based on transport
 		var mcpPath string
 		switch em.cfg.Transport {
@@ -415,7 +409,25 @@ func (em *EndpointManager) protectedResourceMetadataHandler() http.HandlerFunc {
 			mcpPath = ""
 		}
 
-		resourceURL := fmt.Sprintf("%s://%s%s", scheme, host, mcpPath)
+		// Build resource URL: prefer ExternalURL (needed behind TLS-terminating proxies
+		// where r.TLS is always nil), otherwise derive from the request.
+		var resourceURL string
+		if em.provider.config.ExternalURL != "" {
+			resourceURL = em.provider.config.ExternalURL + mcpPath
+		} else {
+			// Build resource URL based on the request
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
+
+			// Use the Host header from the request
+			host := r.Host
+			if host == "" {
+				host = r.URL.Host
+			}
+			resourceURL = fmt.Sprintf("%s://%s%s", scheme, host, mcpPath)
+		}
 		logger.Debugf("OAuth DEBUG: Building protected resource metadata for URL: %s (transport: %s)", resourceURL, em.cfg.Transport)
 
 		provider := em.provider

--- a/internal/auth/oauth/endpoints_test.go
+++ b/internal/auth/oauth/endpoints_test.go
@@ -23,7 +23,11 @@ func createTestConfig() *config.ConfigData {
 		TenantID:       "test-tenant",
 		ClientID:       "test-client",
 		RequiredScopes: []string{"https://management.azure.com/.default"},
-		RedirectURIs:   []string{"http://127.0.0.1:8000/oauth/callback", "http://localhost:8000/oauth/callback"},
+		RedirectURIs: []string{
+			"http://127.0.0.1:8000/oauth/callback",
+			"http://localhost:8000/oauth/callback",
+			"https://example-mcp-client.com/callback",
+		},
 		TokenValidation: auth.TokenValidationConfig{
 			ValidateJWT:      false,
 			ValidateAudience: false,
@@ -52,7 +56,7 @@ func TestEndpointManager_RegisterEndpoints(t *testing.T) {
 		{"GET", "/.well-known/oauth-authorization-server", http.StatusInternalServerError}, // Will fail without real Azure AD
 		{"POST", "/oauth/register", http.StatusBadRequest},                                 // Missing required data
 		{"POST", "/oauth/introspect", http.StatusBadRequest},                               // Missing token param
-		{"GET", "/oauth/callback", http.StatusBadRequest},                                  // Missing required params
+		{"GET", "/oauth/callback", http.StatusBadRequest},                                  // No state → invalid or expired state
 	}
 
 	for _, tc := range testCases {
@@ -268,7 +272,9 @@ func TestCallbackEndpointMissingCode(t *testing.T) {
 	provider, _ := NewAzureOAuthProvider(cfg.OAuthConfig)
 	manager := NewEndpointManager(provider, cfg)
 
-	// Test callback without authorization code
+	// Pre-seed state so the handler can look up the redirect_uri.
+	manager.pendingStates["test-state"] = "https://example-mcp-client.com/callback"
+
 	req := httptest.NewRequest("GET", "/oauth/callback?state=test-state", nil)
 	w := httptest.NewRecorder()
 
@@ -279,15 +285,9 @@ func TestCallbackEndpointMissingCode(t *testing.T) {
 		t.Errorf("Expected status 400 for missing code, got %d", w.Code)
 	}
 
-	// Check that response contains HTML error page
-	contentType := w.Header().Get("Content-Type")
-	if !strings.Contains(contentType, "text/html") {
-		t.Errorf("Expected HTML content type, got %s", contentType)
-	}
-
 	body := w.Body.String()
-	if !strings.Contains(body, "Missing authorization code") {
-		t.Error("Expected error message about missing authorization code")
+	if !strings.Contains(body, "missing code parameter") {
+		t.Errorf("Expected error message about missing code, got: %s", body)
 	}
 }
 
@@ -297,7 +297,7 @@ func TestCallbackEndpointMissingState(t *testing.T) {
 	provider, _ := NewAzureOAuthProvider(cfg.OAuthConfig)
 	manager := NewEndpointManager(provider, cfg)
 
-	// Test callback without state parameter
+	// No state → no pending state entry → 400.
 	req := httptest.NewRequest("GET", "/oauth/callback?code=test-code", nil)
 	w := httptest.NewRecorder()
 
@@ -309,8 +309,8 @@ func TestCallbackEndpointMissingState(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	if !strings.Contains(body, "Missing state parameter") {
-		t.Error("Expected error message about missing state parameter")
+	if !strings.Contains(body, "invalid or expired state") {
+		t.Errorf("Expected invalid state error, got: %s", body)
 	}
 }
 
@@ -320,23 +320,90 @@ func TestCallbackEndpointAuthError(t *testing.T) {
 	provider, _ := NewAzureOAuthProvider(cfg.OAuthConfig)
 	manager := NewEndpointManager(provider, cfg)
 
-	// Test callback with authorization error
-	req := httptest.NewRequest("GET", "/oauth/callback?error=access_denied&error_description=User%20denied%20access", nil)
+	// Pre-seed state so the error can be relayed to the client redirect_uri.
+	manager.pendingStates["test-state"] = "https://example-mcp-client.com/callback"
+
+	req := httptest.NewRequest("GET", "/oauth/callback?error=access_denied&error_description=User%20denied%20access&state=test-state", nil)
+	w := httptest.NewRecorder()
+
+	handler := manager.callbackHandler()
+	handler(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("Expected status 302 for auth error relay, got %d", w.Code)
+	}
+
+	location := w.Header().Get("Location")
+	if !strings.Contains(location, "https://example-mcp-client.com/callback") {
+		t.Errorf("Expected redirect to client URI, got: %s", location)
+	}
+	if !strings.Contains(location, "error=access_denied") {
+		t.Errorf("Expected error param in redirect, got: %s", location)
+	}
+	if !strings.Contains(location, "state=test-state") {
+		t.Errorf("Expected state param in redirect, got: %s", location)
+	}
+}
+
+func TestCallbackEndpointUnknownState(t *testing.T) {
+	cfg := createTestConfig()
+
+	provider, _ := NewAzureOAuthProvider(cfg.OAuthConfig)
+	manager := NewEndpointManager(provider, cfg)
+
+	// No pending state seeded → unknown/expired state.
+	req := httptest.NewRequest("GET", "/oauth/callback?code=test-code&state=unknown-state", nil)
 	w := httptest.NewRecorder()
 
 	handler := manager.callbackHandler()
 	handler(w, req)
 
 	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status 400 for auth error, got %d", w.Code)
+		t.Errorf("Expected status 400 for unknown state, got %d", w.Code)
 	}
 
 	body := w.Body.String()
-	if !strings.Contains(body, "Authorization failed") {
-		t.Error("Expected error message about authorization failure")
+	if !strings.Contains(body, "invalid or expired state") {
+		t.Errorf("Expected invalid state error, got: %s", body)
 	}
-	if !strings.Contains(body, "access_denied") {
-		t.Error("Expected specific error code in response")
+}
+
+func TestCallbackEndpointValidCodeRelayed(t *testing.T) {
+	cfg := createTestConfig()
+
+	provider, _ := NewAzureOAuthProvider(cfg.OAuthConfig)
+	manager := NewEndpointManager(provider, cfg)
+
+	// Pre-seed state as the authorize handler would.
+	manager.pendingStates["my-state"] = "https://example-mcp-client.com/callback"
+
+	req := httptest.NewRequest("GET", "/oauth/callback?code=authcode123&state=my-state", nil)
+	w := httptest.NewRecorder()
+
+	handler := manager.callbackHandler()
+	handler(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("Expected status 302, got %d", w.Code)
+	}
+
+	location := w.Header().Get("Location")
+	if !strings.Contains(location, "https://example-mcp-client.com/callback") {
+		t.Errorf("Expected redirect to client URI, got: %s", location)
+	}
+	if !strings.Contains(location, "code=authcode123") {
+		t.Errorf("Expected code param preserved in redirect, got: %s", location)
+	}
+	if !strings.Contains(location, "state=my-state") {
+		t.Errorf("Expected state param preserved in redirect, got: %s", location)
+	}
+
+	// State must be consumed — a second callback with the same state should fail.
+	req2 := httptest.NewRequest("GET", "/oauth/callback?code=authcode123&state=my-state", nil)
+	w2 := httptest.NewRecorder()
+	handler(w2, req2)
+	if w2.Code != http.StatusBadRequest {
+		t.Errorf("Expected 400 on replayed state, got %d", w2.Code)
 	}
 }
 

--- a/internal/auth/oauth/endpoints_test.go
+++ b/internal/auth/oauth/endpoints_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -831,6 +832,111 @@ func TestAuthorizationProxyRedirectURIValidation(t *testing.T) {
 				if !strings.Contains(location, "login.microsoftonline.com") {
 					t.Errorf("Expected redirect to Azure AD, got: %s", location)
 				}
+			}
+		})
+	}
+}
+
+func TestTokenHandlerValidation(t *testing.T) {
+	cfg := createTestConfig()
+	provider, _ := NewAzureOAuthProvider(cfg.OAuthConfig)
+	manager := NewEndpointManager(provider, cfg)
+	handler := manager.tokenHandler()
+
+	tests := []struct {
+		name       string
+		formValues map[string]string
+		expectCode int
+		expectErr  string
+	}{
+		{
+			name: "missing code",
+			formValues: map[string]string{
+				"grant_type":    "authorization_code",
+				"client_id":     "test-client",
+				"redirect_uri":  "http://127.0.0.1:8000/oauth/callback",
+				"code_verifier": "verifier",
+			},
+			expectCode: http.StatusBadRequest,
+			expectErr:  "authorization code",
+		},
+		{
+			name: "missing client_id",
+			formValues: map[string]string{
+				"grant_type":    "authorization_code",
+				"code":          "test-code",
+				"redirect_uri":  "http://127.0.0.1:8000/oauth/callback",
+				"code_verifier": "verifier",
+			},
+			expectCode: http.StatusBadRequest,
+			expectErr:  "client_id",
+		},
+		{
+			name: "missing redirect_uri",
+			formValues: map[string]string{
+				"grant_type":    "authorization_code",
+				"code":          "test-code",
+				"client_id":     "test-client",
+				"code_verifier": "verifier",
+			},
+			expectCode: http.StatusBadRequest,
+			expectErr:  "redirect_uri",
+		},
+		{
+			name: "missing code_verifier",
+			formValues: map[string]string{
+				"grant_type":   "authorization_code",
+				"code":         "test-code",
+				"client_id":    "test-client",
+				"redirect_uri": "http://127.0.0.1:8000/oauth/callback",
+			},
+			expectCode: http.StatusBadRequest,
+			expectErr:  "code_verifier",
+		},
+		{
+			name: "invalid redirect_uri",
+			formValues: map[string]string{
+				"grant_type":    "authorization_code",
+				"code":          "test-code",
+				"client_id":     "test-client",
+				"redirect_uri":  "http://malicious.com/callback",
+				"code_verifier": "verifier",
+			},
+			expectCode: http.StatusBadRequest,
+			expectErr:  "redirect_uri",
+		},
+		{
+			name: "unsupported grant type",
+			formValues: map[string]string{
+				"grant_type":    "client_credentials",
+				"code":          "test-code",
+				"client_id":     "test-client",
+				"redirect_uri":  "http://127.0.0.1:8000/oauth/callback",
+				"code_verifier": "verifier",
+			},
+			expectCode: http.StatusBadRequest,
+			expectErr:  "grant",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vals := url.Values{}
+			for k, v := range tt.formValues {
+				vals.Set(k, v)
+			}
+			req := httptest.NewRequest("POST", "/oauth2/v2.0/token", strings.NewReader(vals.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+
+			handler(w, req)
+
+			if w.Code != tt.expectCode {
+				t.Errorf("Expected status %d, got %d", tt.expectCode, w.Code)
+			}
+			body := w.Body.String()
+			if !strings.Contains(strings.ToLower(body), strings.ToLower(tt.expectErr)) {
+				t.Errorf("Expected error body to contain %q, got: %s", tt.expectErr, body)
 			}
 		})
 	}

--- a/internal/auth/oauth/endpoints_test.go
+++ b/internal/auth/oauth/endpoints_test.go
@@ -555,6 +555,75 @@ func TestProtectedResourceMetadataEndpointTransportPaths(t *testing.T) {
 	}
 }
 
+func TestProtectedResourceMetadataEndpointExternalURL(t *testing.T) {
+	tests := []struct {
+		name                string
+		externalURL         string
+		transport           string
+		expectedResourceURL string
+		// r.TLS is nil and Host is empty — without ExternalURL this would produce http://example.com
+	}{
+		{
+			name:                "externalURL overrides scheme and host for streamable-http",
+			externalURL:         "https://aks-mcp.platform.example.com",
+			transport:           "streamable-http",
+			expectedResourceURL: "https://aks-mcp.platform.example.com/mcp",
+		},
+		{
+			name:                "externalURL overrides scheme and host for sse",
+			externalURL:         "https://aks-mcp.platform.example.com",
+			transport:           "sse",
+			expectedResourceURL: "https://aks-mcp.platform.example.com/sse",
+		},
+		{
+			name:                "externalURL with no transport path",
+			externalURL:         "https://aks-mcp.platform.example.com",
+			transport:           "",
+			expectedResourceURL: "https://aks-mcp.platform.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createTestConfig()
+			cfg.Transport = tt.transport
+			cfg.OAuthConfig.ExternalURL = tt.externalURL
+
+			provider, _ := NewAzureOAuthProvider(cfg.OAuthConfig)
+			manager := NewEndpointManager(provider, cfg)
+
+			// Request has no TLS and no meaningful Host — ExternalURL must take precedence
+			req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
+			req.Host = ""
+
+			w := httptest.NewRecorder()
+			handler := manager.protectedResourceMetadataHandler()
+			handler(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("Expected status 200, got %d", w.Code)
+			}
+
+			var metadata ProtectedResourceMetadata
+			if err := json.Unmarshal(w.Body.Bytes(), &metadata); err != nil {
+				t.Fatalf("Failed to parse response: %v", err)
+			}
+
+			if metadata.Resource != tt.expectedResourceURL {
+				t.Errorf("Expected resource URL %s, got %s", tt.expectedResourceURL, metadata.Resource)
+			}
+
+			// Authorization server URL should use ExternalURL as base (not http://)
+			if len(metadata.AuthorizationServers) != 1 {
+				t.Fatalf("Expected 1 authorization server, got %d", len(metadata.AuthorizationServers))
+			}
+			if !strings.HasPrefix(metadata.AuthorizationServers[0], "https://") {
+				t.Errorf("Expected authorization server URL to use https://, got %s", metadata.AuthorizationServers[0])
+			}
+		})
+	}
+}
+
 func TestProtectedResourceMetadataEndpointHostHeaders(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -25,6 +25,12 @@ type OAuthConfig struct {
 	// Allowed CORS origins for OAuth endpoints (for security, wildcard "*" should be avoided)
 	AllowedOrigins []string `json:"allowed_origins"`
 
+	// ExternalURL overrides the server URL used in OAuth metadata responses.
+	// Required when the server is behind a TLS-terminating reverse proxy (e.g. Envoy Gateway),
+	// because r.TLS is always nil in that case and http:// URLs would be returned otherwise.
+	// Example: "https://aks-mcp.platform.example.com"
+	ExternalURL string `json:"external_url"`
+
 	// Token validation settings
 	TokenValidation TokenValidationConfig `json:"token_validation"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,6 +123,10 @@ func (cfg *ConfigData) ParseFlags() {
 	allowedCORSOrigins := flag.String("oauth-cors-origins", "",
 		"Comma-separated list of allowed CORS origins for OAuth endpoints (e.g. http://localhost:6274). If empty, no cross-origin requests are allowed for security")
 
+	// OAuth external URL configuration
+	flag.StringVar(&cfg.OAuthConfig.ExternalURL, "oauth-external-url", "",
+		"External base URL of the server (e.g. https://aks-mcp.example.com). Required when behind a TLS-terminating reverse proxy to ensure OAuth metadata uses https:// URLs. Falls back to OAUTH_EXTERNAL_URL env var.")
+
 	// OAuth scopes configuration
 	oauthScopes := flag.String("oauth-scopes", "",
 		"Comma-separated list of OAuth scopes to require (e.g. api://your-app-id/.default). If empty, defaults to https://management.azure.com/.default")
@@ -215,6 +219,14 @@ func (cfg *ConfigData) parseOAuthConfig(additionalRedirectURIs, allowedCORSOrigi
 			audience = strings.TrimSuffix(audience, "/")
 			cfg.OAuthConfig.TokenValidation.ExpectedAudience = audience
 			logger.Infof("OAuth Config: Using custom scopes %v with audience %s", cfg.OAuthConfig.RequiredScopes, audience)
+		}
+	}
+
+	// Load external URL from environment variable if not set via CLI
+	if cfg.OAuthConfig.ExternalURL == "" {
+		if externalURL := os.Getenv("OAUTH_EXTERNAL_URL"); externalURL != "" {
+			cfg.OAuthConfig.ExternalURL = externalURL
+			logger.Debugf("OAuth Config: Using external URL from environment variable OAUTH_EXTERNAL_URL")
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,12 +211,22 @@ func (cfg *ConfigData) parseOAuthConfig(additionalRedirectURIs, allowedCORSOrigi
 				cfg.OAuthConfig.RequiredScopes = append(cfg.OAuthConfig.RequiredScopes, trimmedScope)
 			}
 		}
-		// Update expected audience to match the custom scope resource
+		// Update expected audience to match the custom scope resource.
+		// For api:// scopes the audience is the app URI (api://<app-id>),
+		// regardless of the permission suffix (/.default, /access_as_user, etc.).
 		if len(cfg.OAuthConfig.RequiredScopes) > 0 {
-			// Extract audience from scope (e.g., "api://my-app" from "api://my-app/.default")
 			firstScope := cfg.OAuthConfig.RequiredScopes[0]
-			audience := strings.TrimSuffix(firstScope, "/.default")
-			audience = strings.TrimSuffix(audience, "/")
+			var audience string
+			if strings.HasPrefix(firstScope, "api://") {
+				// Strip permission suffix: "api://app-id/permission" → "api://app-id"
+				withoutScheme := strings.TrimPrefix(firstScope, "api://")
+				appID := strings.SplitN(withoutScheme, "/", 2)[0]
+				audience = "api://" + appID
+			} else {
+				// For https:// scopes (e.g. https://management.azure.com/.default)
+				audience = strings.TrimSuffix(firstScope, "/.default")
+				audience = strings.TrimSuffix(audience, "/")
+			}
 			cfg.OAuthConfig.TokenValidation.ExpectedAudience = audience
 			logger.Infof("OAuth Config: Using custom scopes %v with audience %s", cfg.OAuthConfig.RequiredScopes, audience)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -261,6 +261,12 @@ func TestOAuthScopesConfig(t *testing.T) {
 			expectedScopes:   []string{"api://my-app/.default", "https://management.azure.com/.default"},
 			expectedAudience: "api://my-app",
 		},
+		{
+			name:             "named permission scope strips permission suffix from audience",
+			oauthScopes:      "api://12345678-1234-1234-1234-123456789abc/access_as_user",
+			expectedScopes:   []string{"api://12345678-1234-1234-1234-123456789abc/access_as_user"},
+			expectedAudience: "api://12345678-1234-1234-1234-123456789abc",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When aks-mcp is deployed behind a TLS-terminating reverse proxy (e.g. Envoy Gateway, AGIC), r.TLS is always nil so OAuth metadata endpoints incorrectly return http:// URLs. This causes MCP clients to reject the metadata.

Add --oauth-external-url flag (and OAUTH_EXTERNAL_URL env var fallback) that, when set, is used as the base URL in both /.well-known/oauth-protected-resource and /.well-known/oauth-authorization-server responses instead of deriving the scheme from r.TLS. The existing request-derived logic is preserved as the fallback when the flag is not set.

Expose the option in the Helm chart as oauth.externalURL.

Please see also the related open issue (running a custom image of these code changes): https://github.com/Azure/aks-mcp/issues/365