### PR TITLE
fix: block credential-bearing commands in call_az handler

### DIFF
--- a/internal/components/azapi/handler.go
+++ b/internal/components/azapi/handler.go
@@ -60,8 +60,9 @@ func validateAzCommand(cliCommand string) error {
 		"az ad app credential",
 		"az ad sp credential",
 	}
+	normalizedCmd := strings.Join(strings.Fields(cliCommand), " ")
 	for _, prefix := range credentialDenyPrefixes {
-		if strings.HasPrefix(strings.TrimSpace(cliCommand), prefix) {
+		if strings.HasPrefix(normalizedCmd, prefix) {
 			return fmt.Errorf("command returns credential material and is blocked as a security measure")
 		}
 	}

--- a/internal/components/azapi/handler.go
+++ b/internal/components/azapi/handler.go
@@ -52,9 +52,7 @@ func validateAzCommand(cliCommand string) error {
 	}
 
 	// Block credential-bearing commands: these return live Azure tokens, kubeconfig
-	// material, or service principal secrets. Blocking unconditionally (regardless of
-	// access level) provides defense-in-depth — even if azure-api-mcp's readonly
-	// patterns are misconfigured, these commands never reach execution.
+	// material, or service principal secrets.
 	credentialDenyPrefixes := []string{
 		"az account get-access-token",
 		"az aks get-credentials",

--- a/internal/components/azapi/handler.go
+++ b/internal/components/azapi/handler.go
@@ -51,6 +51,23 @@ func validateAzCommand(cliCommand string) error {
 		}
 	}
 
+	// Block credential-bearing commands: these return live Azure tokens, kubeconfig
+	// material, or service principal secrets. Blocking unconditionally (regardless of
+	// access level) provides defense-in-depth — even if azure-api-mcp's readonly
+	// patterns are misconfigured, these commands never reach execution.
+	credentialDenyPrefixes := []string{
+		"az account get-access-token",
+		"az aks get-credentials",
+		"az fleet get-credentials",
+		"az ad app credential",
+		"az ad sp credential",
+	}
+	for _, prefix := range credentialDenyPrefixes {
+		if strings.HasPrefix(strings.TrimSpace(cliCommand), prefix) {
+			return fmt.Errorf("command returns credential material and is blocked as a security measure")
+		}
+	}
+
 	tokens := strings.Fields(cliCommand)
 
 	// Only inspect "az rest" commands for URL validation

--- a/internal/components/azapi/handler_test.go
+++ b/internal/components/azapi/handler_test.go
@@ -479,6 +479,69 @@ func TestValidateAzCommand(t *testing.T) {
 	}
 }
 
+func TestValidateAzCommand_CredentialBearingCommands(t *testing.T) {
+	credentialCommands := []struct {
+		name  string
+		input string
+	}{
+		{"get-access-token", "az account get-access-token"},
+		{"get-access-token with flags", "az account get-access-token --resource https://management.azure.com/"},
+		{"aks get-credentials", "az aks get-credentials --resource-group rg --name cluster"},
+		{"aks get-credentials with file", "az aks get-credentials --resource-group rg --name cluster --file /tmp/kube"},
+		{"fleet get-credentials", "az fleet get-credentials --resource-group rg --name fleet"},
+		{"ad app credential", "az ad app credential list --id abc"},
+		{"ad sp credential", "az ad sp credential list --id xyz"},
+	}
+
+	for _, tt := range credentialCommands {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAzCommand(tt.input)
+			if err == nil {
+				t.Errorf("validateAzCommand(%q) expected error (credential command), got nil", tt.input)
+			}
+		})
+	}
+}
+
+func TestAzApiHandler_RejectsCredentialBearingCommands(t *testing.T) {
+	credentialCommands := []string{
+		"az account get-access-token",
+		"az account get-access-token --resource https://management.azure.com/",
+		"az aks get-credentials --resource-group rg --name cluster",
+		"az fleet get-credentials --resource-group rg --name fleet",
+	}
+
+	for _, cmd := range credentialCommands {
+		t.Run(cmd, func(t *testing.T) {
+			mockClient := &mockAzClient{
+				executeFunc: func(ctx context.Context, command string) (*azcli.Result, error) {
+					t.Fatal("ExecuteCommand should not be called for blocked credential commands")
+					return nil, nil
+				},
+			}
+			cfg := newTestConfig(30)
+			handler := AzApiHandler(mockClient, cfg)
+
+			req := mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name: "call_az",
+					Arguments: map[string]interface{}{
+						"cli_command": cmd,
+					},
+				},
+			}
+
+			result, err := handler(context.Background(), req)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if !result.IsError {
+				t.Errorf("expected error result for credential command: %s", cmd)
+			}
+		})
+	}
+}
+
 func TestAzApiHandler_RejectsTokenExfiltration(t *testing.T) {
 	mockClient := &mockAzClient{
 		executeFunc: func(ctx context.Context, command string) (*azcli.Result, error) {


### PR DESCRIPTION
## Summary

Block credential-bearing Azure CLI commands (`az account get-access-token`, `az aks get-credentials`, `az fleet get-credentials`, `az ad app credential`, `az ad sp credential`) in the `call_az` handler.

## Test plan

- [ ] `go test ./internal/components/azapi/...` passes
- [ ] `make test` passes