### PR TITLE
fix(oauth): use ExternalURL in WWW-Authenticate header for TLS proxy deployments

### DIFF
--- a/docs/oauth-authentication.md
+++ b/docs/oauth-authentication.md
@@ -271,6 +271,38 @@ curl -H "Authorization: Bearer YOUR_TOKEN" http://localhost:8000/mcp
 - `--oauth-redirects`: Comma-separated list of allowed redirect URIs (required when OAuth enabled)
 - `--oauth-cors-origins`: Comma-separated list of allowed CORS origins for OAuth endpoints (e.g. http://localhost:6274 for MCP Inspector). If empty, no cross-origin requests are allowed for security
 - `--oauth-scopes`: Comma-separated list of OAuth scopes to require (e.g., `api://your-app-id/.default`). If empty, defaults to `https://management.azure.com/.default`
+- `--oauth-external-url`: External base URL of the server (e.g. `https://aks-mcp.example.com`, no trailing slash). Required when running behind a TLS-terminating reverse proxy (Envoy Gateway, AGIC, nginx-ingress, etc.)
+
+## Deploying Behind a TLS-Terminating Reverse Proxy
+
+When running behind Envoy Gateway, AGIC, or any TLS-terminating reverse proxy, set `--oauth-external-url` to the public HTTPS base URL of the server (no trailing slash):
+
+```bash
+./aks-mcp \
+  --transport=streamable-http \
+  --port=8000 \
+  --oauth-enabled \
+  --oauth-tenant-id="$AZURE_TENANT_ID" \
+  --oauth-client-id="$AZURE_CLIENT_ID" \
+  --oauth-redirects="https://aks-mcp.example.com/oauth/callback" \
+  --oauth-external-url="https://aks-mcp.example.com" \
+  --access-level=readonly
+```
+
+The equivalent Helm chart value is `oauth.externalURL`:
+
+```yaml
+# values.yaml
+oauth:
+  enabled: true
+  tenantId: "your-tenant-id"
+  clientId: "your-client-id"
+  redirectURIs:
+    - "https://aks-mcp.example.com/oauth/callback"
+  externalURL: "https://aks-mcp.example.com"
+```
+
+The value can also be set via the `OAUTH_EXTERNAL_URL` environment variable.
 
 ## Restricted Scope Authentication (Assignment Required)
 

--- a/internal/auth/oauth/middleware.go
+++ b/internal/auth/oauth/middleware.go
@@ -316,16 +316,22 @@ func (m *AuthMiddleware) handleAuthError(w http.ResponseWriter, r *http.Request,
 
 	// Add WWW-Authenticate header for 401 responses (RFC 9728 Section 5.1)
 	if authResult.StatusCode == http.StatusUnauthorized {
-		// Build the resource metadata URL
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
+		// Build the resource metadata URL: prefer ExternalURL (needed behind TLS-terminating
+		// proxies where r.TLS is always nil), otherwise derive from the request.
+		var serverURL string
+		if m.provider.config.ExternalURL != "" {
+			serverURL = m.provider.config.ExternalURL
+		} else {
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
+			host := r.Host
+			if host == "" {
+				host = r.URL.Host
+			}
+			serverURL = fmt.Sprintf("%s://%s", scheme, host)
 		}
-		host := r.Host
-		if host == "" {
-			host = r.URL.Host
-		}
-		serverURL := fmt.Sprintf("%s://%s", scheme, host)
 		resourceMetadataURL := fmt.Sprintf("%s/.well-known/oauth-protected-resource", serverURL)
 
 		// RFC 9728 compliant WWW-Authenticate header

--- a/internal/auth/oauth/middleware_test.go
+++ b/internal/auth/oauth/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -115,6 +116,77 @@ func TestAuthMiddleware(t *testing.T) {
 				if wwwAuth == "" {
 					t.Error("Expected WWW-Authenticate header for 401 response")
 				}
+			}
+		})
+	}
+}
+
+func TestHandleAuthErrorWWWAuthenticateExternalURL(t *testing.T) {
+	tests := []struct {
+		name            string
+		externalURL     string
+		expectedURLBase string
+		// r.TLS is nil and Host is set — without ExternalURL this would produce http://
+	}{
+		{
+			name:            "externalURL overrides http scheme from proxy request",
+			externalURL:     "https://aks-mcp.platform.example.com",
+			expectedURLBase: "https://aks-mcp.platform.example.com",
+		},
+		{
+			name:            "no externalURL falls back to request host",
+			externalURL:     "",
+			expectedURLBase: "http://aks-mcp.platform.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &auth.OAuthConfig{
+				Enabled:        true,
+				TenantID:       "test-tenant",
+				ClientID:       "test-client",
+				ExternalURL:    tt.externalURL,
+				RequiredScopes: []string{"https://management.azure.com/.default"},
+				TokenValidation: auth.TokenValidationConfig{
+					ValidateJWT:      false,
+					ValidateAudience: false,
+					ExpectedAudience: "https://management.azure.com/",
+					CacheTTL:         5 * time.Minute,
+					ClockSkew:        1 * time.Minute,
+				},
+			}
+
+			provider, err := NewAzureOAuthProvider(config)
+			if err != nil {
+				t.Fatalf("Failed to create provider: %v", err)
+			}
+			middleware := NewAuthMiddleware(provider, "http://localhost:8000")
+
+			wrappedHandler := middleware.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			// Simulate a request arriving at the pod with no TLS (proxy-terminated)
+			req := httptest.NewRequest("GET", "/mcp", nil)
+			req.Host = "aks-mcp.platform.example.com"
+			// r.TLS is nil — as it always is behind a TLS-terminating proxy
+
+			w := httptest.NewRecorder()
+			wrappedHandler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("Expected 401, got %d", w.Code)
+			}
+
+			wwwAuth := w.Header().Get("WWW-Authenticate")
+			if wwwAuth == "" {
+				t.Fatal("Expected WWW-Authenticate header for 401 response")
+			}
+
+			expectedResourceMetadata := tt.expectedURLBase + "/.well-known/oauth-protected-resource"
+			if !strings.Contains(wwwAuth, expectedResourceMetadata) {
+				t.Errorf("Expected resource_metadata=%q in WWW-Authenticate, got: %s", expectedResourceMetadata, wwwAuth)
 			}
 		})
 	}


### PR DESCRIPTION
Added documentation requested by @gossion from this pr https://github.com/Azure/aks-mcp/pull/364

This pr addresses an issue observed whereby every subsequent command requested prompts a new login flow. This should improve UX