### PR TITLE
feat: add On-Behalf-Of flow for browser-based MCP client support

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
             - "--oauth-external-url"
             - {{ .Values.oauth.externalURL | quote }}
             {{- end }}
+            {{- if .Values.oauth.oboEnabled }}
+            - "--oauth-obo-enabled"
+            - "true"
+            {{- end }}
             {{- end }}
             {{- if .Values.app.logLevel }}
             - "--log-level"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -71,6 +71,9 @@ oauth:
   # Required when the server is behind a TLS-terminating reverse proxy so that
   # OAuth metadata endpoints return https:// URLs instead of http://.
   externalURL: ""
+  # Enable On-Behalf-Of token exchange so tokenAuthOnly tools run as the calling user.
+  # Requires azure.clientSecret (or azure.existingSecret with a client-secret key) to be set.
+  oboEnabled: false
 
 # Application configuration
 config:

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -30,6 +30,7 @@ This document describes the configuration parameters for the AKS-MCP Helm chart.
 | `app.timeout` | Command execution timeout in seconds | `600` |
 | `app.logLevel` | Log level (debug, info, warn, error) | `info` |
 | `app.cache` | Enable cache for better performance | `true` |
+| `app.tokenAuthOnly` | Execute kubectl via Azure AKS RunCommand API using user-provided tokens instead of a local kubeconfig. Required for browser-based MCP clients (e.g. Claude Web). Incompatible with `stdio` transport. | `false` |
 
 ### Azure Authentication
 
@@ -59,8 +60,9 @@ This document describes the configuration parameters for the AKS-MCP Helm chart.
 | `oauth.scopes` | Custom OAuth scopes (e.g., `["api://your-app-id/.default"]`). Use custom App ID URI scope to enforce "Assignment Required" in Azure AD. If empty, defaults to `https://management.azure.com/.default` | `[]` |
 | `oauth.redirectURIs` | Custom redirect URIs | `[]` |
 | `oauth.corsOrigins` | Custom CORS origins | `[]` |
+| `oauth.oboEnabled` | Enable On-Behalf-Of token exchange. Exchanges the user's MCP bearer token for Azure ARM and AKS cluster tokens server-side, allowing browser-based MCP clients (e.g. Claude Web) to run `tokenAuthOnly` tools as the authenticated user. Requires `azure.clientSecret` and the `Azure Service Management > user_impersonation` delegated permission on the app registration. | `false` |
 
-**Note:** See [oauth-authentication.md](./oauth-authentication.md) for detailed OAuth setup instructions, including how to configure restricted scope authentication.
+**Note:** See [oauth-authentication.md](./oauth-authentication.md) for detailed OAuth setup instructions, including how to configure restricted scope authentication and the OBO flow for browser-based clients.
 
 ### Ingress Configuration
 

--- a/docs/oauth-authentication.md
+++ b/docs/oauth-authentication.md
@@ -16,6 +16,7 @@ AKS-MCP now supports OAuth 2.1 authentication using Azure Active Directory as th
 - **Token Introspection**: Implements RFC 7662 token introspection
 - **Transport Support**: Works with both SSE and HTTP Streamable transports
 - **Flexible Configuration**: Supports environment variables and command-line configuration
+- **On-Behalf-Of (OBO) Flow**: Exchanges the user's MCP bearer token for Azure ARM and AKS cluster tokens server-side, enabling browser-based MCP clients (e.g. Claude Web) to run `tokenAuthOnly` kubectl tools as the authenticated user
 
 ## Managed Identity and Service Principal Support
 
@@ -272,6 +273,8 @@ curl -H "Authorization: Bearer YOUR_TOKEN" http://localhost:8000/mcp
 - `--oauth-cors-origins`: Comma-separated list of allowed CORS origins for OAuth endpoints (e.g. http://localhost:6274 for MCP Inspector). If empty, no cross-origin requests are allowed for security
 - `--oauth-scopes`: Comma-separated list of OAuth scopes to require (e.g., `api://your-app-id/.default`). If empty, defaults to `https://management.azure.com/.default`
 - `--oauth-external-url`: External base URL of the server (e.g. `https://aks-mcp.example.com`, no trailing slash). Required when running behind a TLS-terminating reverse proxy (Envoy Gateway, AGIC, nginx-ingress, etc.)
+- `--oauth-obo-enabled`: Enable On-Behalf-Of token exchange (see below). Requires `AZURE_CLIENT_SECRET` to be set.
+- `--default-aks-resource-id`: Default AKS cluster resource ID used when `aks_resource_id` is not supplied by the caller. Falls back to `AZURE_AKS_RESOURCE_ID` env var.
 
 ## Deploying Behind a TLS-Terminating Reverse Proxy
 
@@ -303,6 +306,94 @@ oauth:
 ```
 
 The value can also be set via the `OAUTH_EXTERNAL_URL` environment variable.
+
+## On-Behalf-Of (OBO) Flow for Browser-Based MCP Clients
+
+### Why it is needed
+
+OAuth authentication controls *who can call the MCP server*. Tools that run in `tokenAuthOnly` mode (e.g. `call_kubectl`) execute kubectl commands via the Azure AKS RunCommand API and need an Azure Resource Manager token and an AKS cluster token — separate from the MCP bearer token.
+
+CLI-based clients (e.g. `az` scripts, VS Code with `az login`) can supply these tokens directly via the `X-Azure-Token` header. Browser-based clients such as Claude Web only send the standard `Authorization: Bearer` header and have no mechanism to supply additional Azure tokens.
+
+The OBO flow solves this by performing the token exchange server-side: after OAuth validates the user's bearer token, the server calls Azure AD's token endpoint to trade it for the required Azure tokens. This is transparent to the user.
+
+```
+User authenticates → Bearer token (access_as_user)
+  └─ OBO exchange 1 → ARM token  (https://management.azure.com/user_impersonation)
+  └─ OBO exchange 2 → AKS token  (6dae42f8-4368-4678-94ff-3960e28e3630/.default)
+       └─ injected into request context → call_kubectl succeeds
+```
+
+### Azure AD Application Requirements
+
+In addition to the standard OAuth setup, the app registration requires:
+
+1. **API permission**: `Azure Service Management → user_impersonation` (delegated)
+   ```
+   Azure Portal → App registrations → [Your App] → API permissions
+   → Add a permission → Azure Service Management → user_impersonation
+   → Grant admin consent
+   ```
+
+2. **Client secret**: Required for the OBO token exchange
+   ```
+   Azure Portal → App registrations → [Your App] → Certificates & secrets
+   → New client secret → copy the value
+   ```
+
+Store the client secret as `AZURE_CLIENT_SECRET` in the environment. With the Helm chart, use `azure.clientSecret` or `azure.existingSecret`.
+
+### Helm Chart Configuration
+
+```yaml
+app:
+  tokenAuthOnly: true
+
+oauth:
+  enabled: true
+  tenantId: "<your-tenant-id>"
+  clientId: "<your-app-client-id>"
+  oboEnabled: true
+  scopes:
+    - "api://<your-app-client-id>/access_as_user"
+
+azure:
+  clientSecret: "<your-client-secret>"  # or use existingSecret
+
+extraEnv:
+  - name: AZURE_AKS_RESOURCE_ID
+    value: "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ContainerService/managedClusters/<cluster>"
+```
+
+`AZURE_AKS_RESOURCE_ID` pre-fills the default cluster so MCP clients do not need to supply the cluster resource ID on every request.
+
+### Session Caching
+
+Browser-based MCP clients authenticate once per session and do not re-send the `Authorization` header on follow-up requests. AKS-MCP caches the OBO tokens server-side for the duration of the session (bounded by the bearer token's lifetime, up to 24 hours).
+
+OBO tokens are refreshed proactively five minutes before they expire using the cached bearer token, so sessions remain active without the user needing to reconnect. If the underlying bearer token expires and cannot be refreshed, the session is invalidated and the user is prompted to re-authenticate.
+
+> **Note:** The session cache is in-memory and local to each pod. If you scale beyond a single replica, configure session affinity on your ingress or use a shared cache to avoid users being asked to reconnect when requests hit a different pod.
+
+### AAD-Enabled Clusters and the Cluster Token
+
+The AKS RunCommand API requires two tokens for AAD-enabled clusters:
+
+| Token | Audience | Purpose |
+|-------|----------|---------|
+| ARM token | `https://management.azure.com/` | Authenticates the RunCommand API call |
+| Cluster token | `6dae42f8-4368-4678-94ff-3960e28e3630` | Authorizes the kubectl command inside the cluster (Kubernetes RBAC clusters) |
+
+With OBO enabled, both are obtained automatically. For clusters using Azure RBAC (rather than Kubernetes RBAC), the ARM token is also accepted as the cluster token.
+
+### Troubleshooting OBO
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `OBO exchange requires a client secret` | `AZURE_CLIENT_SECRET` not set | Add client secret to pod environment |
+| `OBO exchange failed: invalid_grant` | Bearer token expired or insufficient permissions | Re-authenticate in the MCP client; verify `user_impersonation` permission is granted |
+| `InvalidAADClusterToken` | Cluster token has wrong audience | Verify the app has `user_impersonation` on Azure Service Management |
+| `X-Azure-Token not found in context` | `--oauth-obo-enabled` flag not passed | Ensure `oauth.oboEnabled: true` in Helm values and chart is up to date |
 
 ## Restricted Scope Authentication (Assignment Required)
 

--- a/internal/auth/oauth/middleware.go
+++ b/internal/auth/oauth/middleware.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Azure/aks-mcp/internal/auth"
+	appctx "github.com/Azure/aks-mcp/internal/ctx"
 	"github.com/Azure/aks-mcp/internal/logger"
 )
 
@@ -16,10 +19,27 @@ type contextKey string
 
 const tokenInfoKey contextKey = "token_info"
 
+// aksServerAppID is the well-known Azure AD application ID for the AKS server,
+// used as the token audience when obtaining cluster tokens for Kubernetes RBAC clusters.
+const aksServerAppID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
+// sessionEntry caches OBO tokens for an established MCP session so that
+// follow-up requests (which carry Mcp-Session-Id but no Authorization header)
+// can still reach downstream tools with the correct Azure tokens.
+type sessionEntry struct {
+	tokenInfo    *auth.TokenInfo
+	bearerToken  string // original bearer token, used to proactively refresh OBO tokens
+	azureToken   string
+	clusterToken string
+	oboExpiresAt time.Time // when the OBO-derived tokens expire (~1h from issue)
+	expiresAt    time.Time // when the session itself expires (bearer token lifetime)
+}
+
 // AuthMiddleware handles OAuth authentication for HTTP requests
 type AuthMiddleware struct {
 	provider  *AzureOAuthProvider
 	serverURL string
+	sessions  sync.Map // Mcp-Session-Id → *sessionEntry
 }
 
 // setCORSHeaders sets CORS headers for OAuth endpoints with origin whitelisting
@@ -66,7 +86,48 @@ func (m *AuthMiddleware) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Perform authentication
+		// Claude Web (and other MCP clients) authenticate once on the initial request,
+		// then send subsequent requests with only Mcp-Session-Id and no Authorization header.
+		// Re-use the cached auth result for these session continuation requests.
+		sessionHandled := false
+		if sessionID := r.Header.Get("Mcp-Session-Id"); sessionID != "" {
+			if val, ok := m.sessions.Load(sessionID); ok {
+				se := val.(*sessionEntry)
+				if time.Now().Before(se.expiresAt) {
+					// Proactively refresh OBO tokens 5 minutes before expiry so the
+					// session stays alive without the user needing to reconnect.
+					if m.provider.config.OBOEnabled && time.Now().After(se.oboExpiresAt.Add(-5*time.Minute)) {
+						logger.Debugf("Session %s: proactively refreshing OBO tokens", sessionID)
+						if !m.refreshSessionOBO(r.Context(), se, sessionID) {
+							// Bearer token has also expired — fall through to full re-auth
+							m.sessions.Delete(sessionID)
+							logger.Debugf("Session %s: OBO refresh failed, re-authentication required", sessionID)
+						}
+					}
+					if _, stillValid := m.sessions.Load(sessionID); stillValid {
+						ctx := context.WithValue(r.Context(), tokenInfoKey, se.tokenInfo)
+						if se.azureToken != "" {
+							ctx = context.WithValue(ctx, appctx.AzureTokenKey, se.azureToken)
+						}
+						if se.clusterToken != "" {
+							ctx = context.WithValue(ctx, appctx.AzureClusterTokenKey, se.clusterToken)
+						}
+						r = r.WithContext(ctx)
+						next.ServeHTTP(w, r)
+						sessionHandled = true
+					}
+				} else {
+					m.sessions.Delete(sessionID)
+					logger.Debugf("Session %s expired, requiring re-authentication", sessionID)
+				}
+			}
+		}
+
+		if sessionHandled {
+			return
+		}
+
+		// Full authentication for new or expired sessions
 		authResult := m.authenticateRequest(r)
 
 		if !authResult.Authenticated {
@@ -75,12 +136,97 @@ func (m *AuthMiddleware) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Add token info to request context
+		// Add token info and OBO tokens to request context
 		ctx := context.WithValue(r.Context(), tokenInfoKey, authResult.TokenInfo)
+		if authResult.AzureToken != "" {
+			ctx = context.WithValue(ctx, appctx.AzureTokenKey, authResult.AzureToken)
+		}
+		if authResult.AzureClusterToken != "" {
+			ctx = context.WithValue(ctx, appctx.AzureClusterTokenKey, authResult.AzureClusterToken)
+		}
 		r = r.WithContext(ctx)
 
-		next.ServeHTTP(w, r)
+		// Wrap the ResponseWriter to capture the Mcp-Session-Id mcp-go assigns on the
+		// response, then cache the full auth result (including bearer token for OBO refresh).
+		oboExpiry := time.Now().Add(55 * time.Minute) // slightly under the 1h ARM token lifetime
+		sessionExpiry := time.Now().Add(24 * time.Hour)
+		if authResult.TokenInfo != nil && authResult.TokenInfo.ExpiresAt.After(time.Now()) && authResult.TokenInfo.ExpiresAt.Before(sessionExpiry) {
+			sessionExpiry = authResult.TokenInfo.ExpiresAt
+		}
+		bearerToken := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		scw := &sessionCapturingWriter{
+			ResponseWriter: w,
+			onSession: func(sessionID string) {
+				m.sessions.Store(sessionID, &sessionEntry{
+					tokenInfo:    authResult.TokenInfo,
+					bearerToken:  bearerToken,
+					azureToken:   authResult.AzureToken,
+					clusterToken: authResult.AzureClusterToken,
+					oboExpiresAt: oboExpiry,
+					expiresAt:    sessionExpiry,
+				})
+				logger.Debugf("Cached auth for session %s (OBO expires: %v, session expires: %v)", sessionID, oboExpiry, sessionExpiry)
+			},
+		}
+		next.ServeHTTP(scw, r)
 	})
+}
+
+// sessionCapturingWriter wraps http.ResponseWriter to capture the Mcp-Session-Id header
+// that mcp-go sets on the response when it creates a new session.
+type sessionCapturingWriter struct {
+	http.ResponseWriter
+	onSession func(string)
+	once      sync.Once
+}
+
+func (w *sessionCapturingWriter) capture() {
+	if sessionID := w.ResponseWriter.Header().Get("Mcp-Session-Id"); sessionID != "" {
+		w.onSession(sessionID)
+	}
+}
+
+func (w *sessionCapturingWriter) WriteHeader(code int) {
+	w.once.Do(w.capture)
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *sessionCapturingWriter) Write(b []byte) (int, error) {
+	w.once.Do(w.capture)
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *sessionCapturingWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// refreshSessionOBO uses the cached bearer token to get fresh OBO tokens and updates
+// the session entry in-place. Returns false if the bearer token has expired.
+func (m *AuthMiddleware) refreshSessionOBO(ctx context.Context, se *sessionEntry, sessionID string) bool {
+	if se.bearerToken == "" {
+		return false
+	}
+
+	armToken, err := m.provider.ExchangeOBO(ctx, se.bearerToken, "https://management.azure.com/user_impersonation")
+	if err != nil {
+		logger.Warnf("Session %s: ARM OBO refresh failed: %v", sessionID, err)
+		return false
+	}
+
+	se.azureToken = armToken
+	se.oboExpiresAt = time.Now().Add(55 * time.Minute)
+
+	if clusterToken, err := m.provider.ExchangeOBO(ctx, se.bearerToken, aksServerAppID+"/.default"); err != nil {
+		logger.Warnf("Session %s: cluster OBO refresh failed: %v", sessionID, err)
+	} else {
+		se.clusterToken = clusterToken
+	}
+
+	m.sessions.Store(sessionID, se)
+	logger.Debugf("Session %s: OBO tokens refreshed successfully", sessionID)
+	return true
 }
 
 // shouldSkipAuth determines if authentication should be skipped for this request
@@ -178,11 +324,37 @@ func (m *AuthMiddleware) authenticateRequest(r *http.Request) *auth.AuthResult {
 		}
 	}
 
-	return &auth.AuthResult{
+	result := &auth.AuthResult{
 		Authenticated: true,
 		TokenInfo:     tokenInfo,
 		StatusCode:    http.StatusOK,
 	}
+
+	// OBO exchange: trade the user's MCP bearer token for tokens needed by downstream tools.
+	if m.provider.config.OBOEnabled {
+		// ARM token — authenticates the RunCommand API call against Azure management plane.
+		armToken, err := m.provider.ExchangeOBO(r.Context(), token, "https://management.azure.com/user_impersonation")
+		if err != nil {
+			logger.Errorf("OBO ARM exchange failed for user %s: %v", tokenInfo.Subject, err)
+			return &auth.AuthResult{
+				Authenticated: false,
+				Error:         fmt.Sprintf("OBO token exchange failed: %v", err),
+				StatusCode:    http.StatusUnauthorized,
+			}
+		}
+		result.AzureToken = armToken
+
+		// AKS cluster token — passed as clusterToken in RunCommand requests for AAD-enabled clusters
+		// that use Kubernetes RBAC. Audience: aksServerAppID (AKS server app).
+		clusterToken, err := m.provider.ExchangeOBO(r.Context(), token, aksServerAppID+"/.default")
+		if err != nil {
+			logger.Warnf("OBO cluster token exchange failed for user %s: %v — kubectl on AAD clusters may fail", tokenInfo.Subject, err)
+		} else {
+			result.AzureClusterToken = clusterToken
+		}
+	}
+
+	return result
 }
 
 // validateScopes checks if the token has required scopes

--- a/internal/auth/oauth/middleware_test.go
+++ b/internal/auth/oauth/middleware_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/aks-mcp/internal/auth"
+	appctx "github.com/Azure/aks-mcp/internal/ctx"
 )
 
 // GetTokenInfo extracts token information from request context (test helper)
@@ -322,4 +324,301 @@ func TestGetTokenInfo(t *testing.T) {
 	if ok {
 		t.Error("Expected not to find token info in empty context")
 	}
+}
+
+func newOBOMiddleware(t *testing.T, oboEnabled bool, oboHandler http.Handler) *AuthMiddleware {
+	t.Helper()
+	cfg := &auth.OAuthConfig{
+		Enabled:      true,
+		TenantID:     "test-tenant",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		OBOEnabled:   oboEnabled,
+		TokenValidation: auth.TokenValidationConfig{
+			ValidateJWT:      false,
+			ValidateAudience: false,
+			ExpectedAudience: "https://management.azure.com/",
+		},
+	}
+	p, err := NewAzureOAuthProvider(cfg)
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+	if oboHandler != nil {
+		p.httpClient = &http.Client{
+			Transport: &roundTripperFunc{
+				fn: func(req *http.Request) (*http.Response, error) {
+					w := httptest.NewRecorder()
+					oboHandler.ServeHTTP(w, req)
+					return w.Result(), nil
+				},
+			},
+		}
+	}
+	return NewAuthMiddleware(p, "http://localhost:8000")
+}
+
+func TestSessionCapturingWriter(t *testing.T) {
+	t.Run("captures session ID set in response header", func(t *testing.T) {
+		var captured string
+		scw := &sessionCapturingWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			onSession:      func(id string) { captured = id },
+		}
+		scw.ResponseWriter.Header().Set("Mcp-Session-Id", "session-abc")
+		scw.WriteHeader(http.StatusOK)
+
+		if captured != "session-abc" {
+			t.Errorf("expected session-abc, got %q", captured)
+		}
+	})
+
+	t.Run("captures on Write when WriteHeader not called", func(t *testing.T) {
+		var captured string
+		rec := httptest.NewRecorder()
+		scw := &sessionCapturingWriter{
+			ResponseWriter: rec,
+			onSession:      func(id string) { captured = id },
+		}
+		rec.Header().Set("Mcp-Session-Id", "session-xyz")
+		_, _ = scw.Write([]byte("body"))
+
+		if captured != "session-xyz" {
+			t.Errorf("expected session-xyz, got %q", captured)
+		}
+	})
+
+	t.Run("does not capture when header absent", func(t *testing.T) {
+		called := false
+		scw := &sessionCapturingWriter{
+			ResponseWriter: httptest.NewRecorder(),
+			onSession:      func(_ string) { called = true },
+		}
+		scw.WriteHeader(http.StatusOK)
+
+		if called {
+			t.Error("onSession should not be called when Mcp-Session-Id is absent")
+		}
+	})
+
+	t.Run("only fires once despite multiple writes", func(t *testing.T) {
+		count := 0
+		rec := httptest.NewRecorder()
+		scw := &sessionCapturingWriter{
+			ResponseWriter: rec,
+			onSession:      func(_ string) { count++ },
+		}
+		rec.Header().Set("Mcp-Session-Id", "session-once")
+		scw.WriteHeader(http.StatusOK)
+		_, _ = scw.Write([]byte("a"))
+		_, _ = scw.Write([]byte("b"))
+
+		if count != 1 {
+			t.Errorf("expected onSession called once, got %d", count)
+		}
+	})
+}
+
+func TestSessionContinuation(t *testing.T) {
+	m := newOBOMiddleware(t, false, nil)
+
+	tokenInfo := &auth.TokenInfo{
+		AccessToken: "original-token",
+		Subject:     "user123",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	sessionID := "mcp-session-test-123"
+	m.sessions.Store(sessionID, &sessionEntry{
+		tokenInfo:    tokenInfo,
+		azureToken:   "arm-token",
+		clusterToken: "cluster-token",
+		oboExpiresAt: time.Now().Add(55 * time.Minute),
+		expiresAt:    time.Now().Add(time.Hour),
+	})
+
+	var gotAzureToken, gotClusterToken string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAzureToken, _ = r.Context().Value(appctx.AzureTokenKey).(string)
+		gotClusterToken, _ = r.Context().Value(appctx.AzureClusterTokenKey).(string)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	w := httptest.NewRecorder()
+	m.Middleware(handler).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if gotAzureToken != "arm-token" {
+		t.Errorf("expected arm-token in context, got %q", gotAzureToken)
+	}
+	if gotClusterToken != "cluster-token" {
+		t.Errorf("expected cluster-token in context, got %q", gotClusterToken)
+	}
+}
+
+func TestSessionContinuation_ExpiredSession(t *testing.T) {
+	m := newOBOMiddleware(t, false, nil)
+
+	sessionID := "mcp-session-expired"
+	m.sessions.Store(sessionID, &sessionEntry{
+		tokenInfo: &auth.TokenInfo{Subject: "user"},
+		expiresAt: time.Now().Add(-time.Minute), // already expired
+	})
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	w := httptest.NewRecorder()
+	m.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(w, req)
+
+	// Expired session has no auth header → should be 401
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for expired session, got %d", w.Code)
+	}
+	if _, ok := m.sessions.Load(sessionID); ok {
+		t.Error("expired session should have been deleted")
+	}
+}
+
+func TestSessionContinuation_UnknownSessionFallsThrough(t *testing.T) {
+	m := newOBOMiddleware(t, false, nil)
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("Mcp-Session-Id", "unknown-session")
+	w := httptest.NewRecorder()
+	m.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(w, req)
+
+	// No auth header and unknown session → 401
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for unknown session, got %d", w.Code)
+	}
+}
+
+func TestOBOTokensInjectedInContext(t *testing.T) {
+	callCount := 0
+	oboHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"access_token":"obo-token-%d"}`, callCount)
+	})
+
+	m := newOBOMiddleware(t, true, oboHandler)
+
+	var gotAzure, gotCluster string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAzure, _ = r.Context().Value(appctx.AzureTokenKey).(string)
+		gotCluster, _ = r.Context().Value(appctx.AzureClusterTokenKey).(string)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer header.payload.signature")
+	w := httptest.NewRecorder()
+	m.Middleware(handler).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if gotAzure == "" {
+		t.Error("expected ARM token in context, got empty string")
+	}
+	if gotCluster == "" {
+		t.Error("expected cluster token in context, got empty string")
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 OBO calls (ARM + cluster), got %d", callCount)
+	}
+}
+
+func TestOBOARMFailureCauses401(t *testing.T) {
+	oboHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprint(w, `{"error":"invalid_grant","error_description":"expired"}`)
+	})
+
+	m := newOBOMiddleware(t, true, oboHandler)
+
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer header.payload.signature")
+	w := httptest.NewRecorder()
+	m.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 when OBO fails, got %d", w.Code)
+	}
+}
+
+func TestRefreshSessionOBO(t *testing.T) {
+	t.Run("success refreshes tokens and updates session", func(t *testing.T) {
+		callCount := 0
+		oboHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"access_token":"refreshed-%d"}`, callCount)
+		})
+
+		m := newOBOMiddleware(t, true, oboHandler)
+		se := &sessionEntry{
+			bearerToken:  "header.payload.signature",
+			azureToken:   "old-arm",
+			clusterToken: "old-cluster",
+			oboExpiresAt: time.Now().Add(-time.Minute),
+			expiresAt:    time.Now().Add(time.Hour),
+		}
+
+		ok := m.refreshSessionOBO(context.Background(), se, "session-1")
+
+		if !ok {
+			t.Error("expected refresh to succeed")
+		}
+		if se.azureToken == "old-arm" {
+			t.Error("ARM token should have been updated")
+		}
+		if se.oboExpiresAt.Before(time.Now()) {
+			t.Error("oboExpiresAt should be in the future after refresh")
+		}
+		if callCount != 2 {
+			t.Errorf("expected 2 OBO calls, got %d", callCount)
+		}
+	})
+
+	t.Run("no bearer token returns false", func(t *testing.T) {
+		m := newOBOMiddleware(t, true, nil)
+		se := &sessionEntry{bearerToken: ""}
+
+		ok := m.refreshSessionOBO(context.Background(), se, "session-2")
+		if ok {
+			t.Error("expected false when no bearer token stored")
+		}
+	})
+
+	t.Run("ARM OBO failure returns false", func(t *testing.T) {
+		oboHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"error":"invalid_grant"}`)
+		})
+
+		m := newOBOMiddleware(t, true, oboHandler)
+		se := &sessionEntry{
+			bearerToken:  "header.payload.signature",
+			azureToken:   "old",
+			oboExpiresAt: time.Now().Add(-time.Minute),
+		}
+
+		ok := m.refreshSessionOBO(context.Background(), se, "session-3")
+		if ok {
+			t.Error("expected false when ARM OBO fails")
+		}
+		if se.azureToken != "old" {
+			t.Error("token should not be modified on failure")
+		}
+	})
 }

--- a/internal/auth/oauth/provider.go
+++ b/internal/auth/oauth/provider.go
@@ -495,6 +495,69 @@ func (p *AzureOAuthProvider) getPublicKey(kid string, issuer string) (*rsa.Publi
 	return nil, fmt.Errorf("key with ID %s not found in JWKS (available: %v)", kid, foundKeyIds)
 }
 
+// ExchangeOBO exchanges a user's bearer token for a token scoped to the given resource using the
+// Azure AD On-Behalf-Of flow.
+func (p *AzureOAuthProvider) ExchangeOBO(ctx context.Context, userToken string, scope string) (string, error) {
+	if p.config.ClientSecret == "" {
+		return "", fmt.Errorf("OBO exchange requires a client secret (set AZURE_CLIENT_SECRET)")
+	}
+
+	tokenURL := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", p.config.TenantID)
+
+	data := url.Values{}
+	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+	data.Set("assertion", userToken)
+	data.Set("client_id", p.config.ClientID)
+	data.Set("client_secret", p.config.ClientSecret)
+	data.Set("scope", scope)
+	data.Set("requested_token_use", "on_behalf_of")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create OBO request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("OBO token request failed: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Errorf("Failed to close OBO response body: %v", err)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read OBO response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Error != "" {
+			return "", fmt.Errorf("OBO exchange failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+		}
+		return "", fmt.Errorf("OBO exchange failed with status %d", resp.StatusCode)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"` // #nosec G101
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("failed to parse OBO token response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("OBO exchange returned empty access token")
+	}
+
+	logger.Debugf("OBO exchange successful for scope %s", scope)
+	return tokenResp.AccessToken, nil
+}
+
 // parseRSAPublicKey parses RSA public key from JWK format
 func parseRSAPublicKey(nStr, eStr string) (*rsa.PublicKey, error) {
 	// Decode base64url-encoded modulus

--- a/internal/auth/oauth/provider.go
+++ b/internal/auth/oauth/provider.go
@@ -518,7 +518,7 @@ func (p *AzureOAuthProvider) ExchangeOBO(ctx context.Context, userToken string, 
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := p.httpClient.Do(req)
+	resp, err := p.httpClient.Do(req) // #nosec G704
 	if err != nil {
 		return "", fmt.Errorf("OBO token request failed: %w", err)
 	}
@@ -545,7 +545,7 @@ func (p *AzureOAuthProvider) ExchangeOBO(ctx context.Context, userToken string, 
 	}
 
 	var tokenResp struct {
-		AccessToken string `json:"access_token"` // #nosec G101
+		AccessToken string `json:"access_token"` // #nosec G101 G117
 	}
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		return "", fmt.Errorf("failed to parse OBO token response: %w", err)

--- a/internal/auth/oauth/provider_test.go
+++ b/internal/auth/oauth/provider_test.go
@@ -386,3 +386,197 @@ type roundTripperFunc struct {
 func (f *roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f.fn(req)
 }
+
+func oboConfig() *auth.OAuthConfig {
+	return &auth.OAuthConfig{
+		Enabled:      true,
+		TenantID:     "test-tenant",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		TokenValidation: auth.TokenValidationConfig{
+			ValidateJWT:      false,
+			ValidateAudience: false,
+			ExpectedAudience: "https://management.azure.com/",
+			CacheTTL:         5 * time.Minute,
+			ClockSkew:        1 * time.Minute,
+		},
+	}
+}
+
+func newProviderWithTransport(t *testing.T, cfg *auth.OAuthConfig, handler http.Handler) *AzureOAuthProvider {
+	t.Helper()
+	p, err := NewAzureOAuthProvider(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+	p.httpClient = &http.Client{
+		Transport: &roundTripperFunc{
+			fn: func(req *http.Request) (*http.Response, error) {
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+				return w.Result(), nil
+			},
+		},
+	}
+	return p
+}
+
+func TestExchangeOBO(t *testing.T) {
+	tests := []struct {
+		name          string
+		clientSecret  string
+		scope         string
+		handlerStatus int
+		handlerBody   string
+		wantToken     string
+		wantErrSubstr string
+	}{
+		{
+			name:          "success returns access token",
+			clientSecret:  "secret",
+			scope:         "https://management.azure.com/user_impersonation",
+			handlerStatus: http.StatusOK,
+			handlerBody:   `{"access_token":"arm-token-xyz","token_type":"Bearer"}`,
+			wantToken:     "arm-token-xyz",
+		},
+		{
+			name:          "success with cluster scope",
+			clientSecret:  "secret",
+			scope:         "6dae42f8-4368-4678-94ff-3960e28e3630/.default",
+			handlerStatus: http.StatusOK,
+			handlerBody:   `{"access_token":"cluster-token-abc","token_type":"Bearer"}`,
+			wantToken:     "cluster-token-abc",
+		},
+		{
+			name:          "missing client secret errors immediately",
+			clientSecret:  "",
+			scope:         "https://management.azure.com/user_impersonation",
+			wantErrSubstr: "client secret",
+		},
+		{
+			name:          "azure ad error response",
+			clientSecret:  "secret",
+			scope:         "https://management.azure.com/user_impersonation",
+			handlerStatus: http.StatusBadRequest,
+			handlerBody:   `{"error":"invalid_grant","error_description":"Token is expired"}`,
+			wantErrSubstr: "invalid_grant",
+		},
+		{
+			name:          "non-json error response",
+			clientSecret:  "secret",
+			scope:         "https://management.azure.com/user_impersonation",
+			handlerStatus: http.StatusInternalServerError,
+			handlerBody:   `internal server error`,
+			wantErrSubstr: "status 500",
+		},
+		{
+			name:          "empty access token in response",
+			clientSecret:  "secret",
+			scope:         "https://management.azure.com/user_impersonation",
+			handlerStatus: http.StatusOK,
+			handlerBody:   `{"token_type":"Bearer"}`,
+			wantErrSubstr: "empty access token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := oboConfig()
+			cfg.ClientSecret = tt.clientSecret
+
+			var p *AzureOAuthProvider
+			if tt.clientSecret != "" {
+				handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if err := r.ParseForm(); err != nil {
+						t.Errorf("Failed to parse form: %v", err)
+					}
+					if r.FormValue("grant_type") != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+						t.Errorf("Expected OBO grant type, got %s", r.FormValue("grant_type"))
+					}
+					if r.FormValue("scope") != tt.scope {
+						t.Errorf("Expected scope %q, got %q", tt.scope, r.FormValue("scope"))
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(tt.handlerStatus)
+					_, _ = fmt.Fprint(w, tt.handlerBody)
+				})
+				p = newProviderWithTransport(t, cfg, handler)
+			} else {
+				var err error
+				p, err = NewAzureOAuthProvider(cfg)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			got, err := p.ExchangeOBO(context.Background(), "user-bearer-token", tt.scope)
+
+			if tt.wantErrSubstr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrSubstr)
+				}
+				if !contains(err.Error(), tt.wantErrSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErrSubstr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantToken {
+				t.Errorf("expected token %q, got %q", tt.wantToken, got)
+			}
+		})
+	}
+}
+
+func TestExchangeOBO_RequestFields(t *testing.T) {
+	cfg := oboConfig()
+
+	var capturedForm map[string]string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		capturedForm = map[string]string{
+			"grant_type":          r.FormValue("grant_type"),
+			"assertion":           r.FormValue("assertion"),
+			"client_id":           r.FormValue("client_id"),
+			"client_secret":       r.FormValue("client_secret"),
+			"scope":               r.FormValue("scope"),
+			"requested_token_use": r.FormValue("requested_token_use"),
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"access_token":"tok"}`)
+	})
+	p := newProviderWithTransport(t, cfg, handler)
+
+	_, err := p.ExchangeOBO(context.Background(), "my-bearer", "https://management.azure.com/user_impersonation")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedForm["grant_type"] != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+		t.Errorf("wrong grant_type: %s", capturedForm["grant_type"])
+	}
+	if capturedForm["assertion"] != "my-bearer" {
+		t.Errorf("wrong assertion: %s", capturedForm["assertion"])
+	}
+	if capturedForm["client_id"] != "test-client" {
+		t.Errorf("wrong client_id: %s", capturedForm["client_id"])
+	}
+	if capturedForm["requested_token_use"] != "on_behalf_of" {
+		t.Errorf("wrong requested_token_use: %s", capturedForm["requested_token_use"])
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -17,7 +17,7 @@ type OAuthConfig struct {
 	ClientID string `json:"client_id"`
 
 	// Azure AD application client secret (required for OBO flow)
-	ClientSecret string `json:"client_secret"` // #nosec G101
+	ClientSecret string `json:"client_secret"` // #nosec G101 G117
 
 	// Enable On-Behalf-Of token exchange: exchanges the user's MCP bearer token for an
 	// Azure Resource Manager token so tokenAuthOnly tools can run as the calling user.

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -16,6 +16,13 @@ type OAuthConfig struct {
 	// Azure AD application (client) ID
 	ClientID string `json:"client_id"`
 
+	// Azure AD application client secret (required for OBO flow)
+	ClientSecret string `json:"client_secret"` // #nosec G101
+
+	// Enable On-Behalf-Of token exchange: exchanges the user's MCP bearer token for an
+	// Azure Resource Manager token so tokenAuthOnly tools can run as the calling user.
+	OBOEnabled bool `json:"obo_enabled"`
+
 	// Required OAuth scopes for accessing AKS-MCP
 	RequiredScopes []string `json:"required_scopes"`
 
@@ -89,6 +96,13 @@ type AuthResult struct {
 
 	// Token information (if authenticated)
 	TokenInfo *TokenInfo `json:"token_info,omitempty"`
+
+	// AzureToken is an ARM-scoped token obtained via OBO exchange, ready for AKS RunCommand calls.
+	AzureToken string `json:"azure_token,omitempty"` // #nosec G101
+
+	// AzureClusterToken is an AKS-scoped token (audience: 6dae42f8-4368-4678-94ff-3960e28e3630)
+	// used as the clusterToken in RunCommand requests against AAD + Kubernetes RBAC clusters.
+	AzureClusterToken string `json:"azure_cluster_token,omitempty"` // #nosec G101
 
 	// Error message (if authentication failed)
 	Error string `json:"error,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,10 @@ type ConfigData struct {
 	// When enabled, supported tools (e.g., kubectl) are executed via Azure AKS RunCommand API using user-provided tokens
 	// When disabled (default), tools are executed locally with default authentication (e.g., kubeconfig for Kubernetes tools)
 	TokenAuthOnly bool
+
+	// DefaultAKSResourceID is the default AKS cluster resource ID used when aks_resource_id is not provided by the caller.
+	// Set via --default-aks-resource-id flag or AZURE_AKS_RESOURCE_ID environment variable.
+	DefaultAKSResourceID string
 }
 
 // NewConfig creates and returns a new configuration instance
@@ -131,6 +135,10 @@ func (cfg *ConfigData) ParseFlags() {
 	oauthScopes := flag.String("oauth-scopes", "",
 		"Comma-separated list of OAuth scopes to require (e.g. api://your-app-id/.default). If empty, defaults to https://management.azure.com/.default")
 
+	// OBO configuration
+	flag.BoolVar(&cfg.OAuthConfig.OBOEnabled, "oauth-obo-enabled", false,
+		"Enable On-Behalf-Of token exchange: trades the user's MCP bearer token for an ARM token so tokenAuthOnly tools run as the calling user (requires AZURE_CLIENT_SECRET)")
+
 	// Component configuration
 	enabledComponents := flag.String("enabled-components", "",
 		"Comma-separated list of enabled components (empty means all components enabled). Available: az_cli,monitor,fleet,network,compute,detectors,advisor,inspektorgadget,kubectl,helm,cilium,hubble")
@@ -142,6 +150,10 @@ func (cfg *ConfigData) ParseFlags() {
 	// Token-only authentication configuration
 	flag.BoolVar(&cfg.TokenAuthOnly, "token-auth-only", false,
 		"Enable token-only authentication mode for supported tools (e.g., kubectl uses Azure AKS RunCommand API with user-provided tokens instead of local kubeconfig)")
+
+	// Default AKS resource ID
+	flag.StringVar(&cfg.DefaultAKSResourceID, "default-aks-resource-id", "",
+		"Default AKS cluster resource ID used when aks_resource_id is not supplied by the caller (e.g. /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{cluster}). Falls back to AZURE_AKS_RESOURCE_ID env var.")
 
 	// Logging settings
 	flag.StringVar(&cfg.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
@@ -185,6 +197,11 @@ func (cfg *ConfigData) ParseFlags() {
 	if err := cfg.parseOAuthConfig(*additionalRedirectURIs, *allowedCORSOrigins, *oauthScopes); err != nil {
 		fmt.Printf("OAuth configuration error: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Fall back to environment variable for default AKS resource ID
+	if cfg.DefaultAKSResourceID == "" {
+		cfg.DefaultAKSResourceID = os.Getenv("AZURE_AKS_RESOURCE_ID")
 	}
 
 	// Parse enabled components
@@ -237,6 +254,14 @@ func (cfg *ConfigData) parseOAuthConfig(additionalRedirectURIs, allowedCORSOrigi
 		if externalURL := os.Getenv("OAUTH_EXTERNAL_URL"); externalURL != "" {
 			cfg.OAuthConfig.ExternalURL = externalURL
 			logger.Debugf("OAuth Config: Using external URL from environment variable OAUTH_EXTERNAL_URL")
+		}
+	}
+
+	// Load client secret for OBO flow from environment variable
+	if cfg.OAuthConfig.ClientSecret == "" {
+		if secret := os.Getenv("AZURE_CLIENT_SECRET"); secret != "" {
+			cfg.OAuthConfig.ClientSecret = secret
+			logger.Debugf("OAuth Config: Using client secret from environment variable AZURE_CLIENT_SECRET")
 		}
 	}
 

--- a/internal/ctx/context.go
+++ b/internal/ctx/context.go
@@ -6,3 +6,8 @@ type ContextKey string
 // This is the name of the HTTP header, not a hardcoded credential.
 // #nosec G101
 const AzureTokenKey ContextKey = "X-Azure-Token"
+
+// AzureClusterTokenKey is the context key for the AKS-scoped token used as the Kubernetes cluster token
+// in RunCommand requests against AAD-enabled clusters (audience: 6dae42f8-4368-4678-94ff-3960e28e3630).
+// #nosec G101
+const AzureClusterTokenKey ContextKey = "X-Azure-Cluster-Token"

--- a/internal/k8s/registry.go
+++ b/internal/k8s/registry.go
@@ -14,7 +14,7 @@ const (
 	AccessLevelReadWrite = "readwrite"
 )
 
-func createCallKubectlTool(accessLevel string) mcp.Tool {
+func createCallKubectlTool(accessLevel string, defaultAKSResourceID string) mcp.Tool {
 	var description string
 
 	readCommands := strings.Join(security.KubectlReadOperations, ", ")
@@ -70,23 +70,30 @@ Examples:
 - command='kubectl logs nginx-pod -f'`, readCommands)
 	}
 
+	resourceIDDesc := "Full Azure Resource ID of the AKS cluster (e.g., /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{clusterName})"
+	if defaultAKSResourceID != "" {
+		resourceIDDesc = fmt.Sprintf("Full Azure Resource ID of the AKS cluster. Defaults to %s if not provided.", defaultAKSResourceID)
+	}
+
+	resourceIDOpts := []mcp.PropertyOption{mcp.Description(resourceIDDesc)}
+	if defaultAKSResourceID == "" {
+		resourceIDOpts = append(resourceIDOpts, mcp.Required())
+	}
+
 	return mcp.NewTool("call_kubectl",
 		mcp.WithDescription(description),
 		mcp.WithString("command",
 			mcp.Required(),
 			mcp.Description("Full kubectl command to execute (e.g., 'kubectl get pods -n default', 'kubectl describe deployment myapp', 'kubectl logs nginx-pod -f')"),
 		),
-		mcp.WithString("aks_resource_id",
-			mcp.Required(),
-			mcp.Description("Full Azure Resource ID of the AKS cluster (e.g., /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{clusterName})"),
-		),
+		mcp.WithString("aks_resource_id", resourceIDOpts...),
 	)
 }
 
-func RegisterKubectlTools(accessLevel string, useUnifiedTool bool, tokenAuthOnly bool) []mcp.Tool {
+func RegisterKubectlTools(accessLevel string, useUnifiedTool bool, tokenAuthOnly bool, defaultAKSResourceID string) []mcp.Tool {
 	if tokenAuthOnly {
 		return []mcp.Tool{
-			createCallKubectlTool(accessLevel),
+			createCallKubectlTool(accessLevel, defaultAKSResourceID),
 		}
 	}
 

--- a/internal/k8s/registry_test.go
+++ b/internal/k8s/registry_test.go
@@ -1,0 +1,147 @@
+package k8s
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCreateCallKubectlTool_ResourceIDRequired_WhenNoDefault(t *testing.T) {
+	tool := createCallKubectlTool("readonly", "")
+
+	schemaBytes, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("failed to marshal input schema: %v", err)
+	}
+
+	var schema struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+		t.Fatalf("failed to unmarshal schema: %v", err)
+	}
+
+	found := false
+	for _, r := range schema.Required {
+		if r == "aks_resource_id" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected aks_resource_id to be required when no default provided, required fields: %v", schema.Required)
+	}
+}
+
+func TestCreateCallKubectlTool_ResourceIDOptional_WhenDefaultSet(t *testing.T) {
+	tool := createCallKubectlTool("readonly", "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster")
+
+	schemaBytes, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("failed to marshal input schema: %v", err)
+	}
+
+	var schema struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+		t.Fatalf("failed to unmarshal schema: %v", err)
+	}
+
+	for _, r := range schema.Required {
+		if r == "aks_resource_id" {
+			t.Errorf("aks_resource_id should be optional when default is configured, but found in required: %v", schema.Required)
+		}
+	}
+}
+
+func TestCreateCallKubectlTool_CommandAlwaysRequired(t *testing.T) {
+	tests := []struct {
+		name              string
+		defaultResourceID string
+	}{
+		{"no default", ""},
+		{"with default", "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := createCallKubectlTool("readonly", tt.defaultResourceID)
+
+			schemaBytes, _ := json.Marshal(tool.InputSchema)
+			var schema struct {
+				Required []string `json:"required"`
+			}
+			_ = json.Unmarshal(schemaBytes, &schema)
+
+			found := false
+			for _, r := range schema.Required {
+				if r == "command" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("command should always be required, required fields: %v", schema.Required)
+			}
+		})
+	}
+}
+
+func TestCreateCallKubectlTool_DescriptionContainsDefault(t *testing.T) {
+	defaultID := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/mycluster"
+	tool := createCallKubectlTool("readonly", defaultID)
+
+	schemaBytes, _ := json.Marshal(tool.InputSchema)
+	var schema struct {
+		Properties map[string]struct {
+			Description string `json:"description"`
+		} `json:"properties"`
+	}
+	_ = json.Unmarshal(schemaBytes, &schema)
+
+	prop, ok := schema.Properties["aks_resource_id"]
+	if !ok {
+		t.Fatal("aks_resource_id property not found in schema")
+	}
+	if prop.Description == "" {
+		t.Error("expected non-empty description for aks_resource_id")
+	}
+}
+
+func TestCreateCallKubectlTool_Name(t *testing.T) {
+	tool := createCallKubectlTool("readonly", "")
+	if tool.Name != "call_kubectl" {
+		t.Errorf("expected tool name call_kubectl, got %q", tool.Name)
+	}
+}
+
+func TestRegisterKubectlTools_TokenAuthOnly(t *testing.T) {
+	tools := RegisterKubectlTools("readonly", true, true, "")
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool in tokenAuthOnly mode, got %d", len(tools))
+	}
+	if tools[0].Name != "call_kubectl" {
+		t.Errorf("expected call_kubectl, got %q", tools[0].Name)
+	}
+}
+
+func TestRegisterKubectlTools_TokenAuthOnly_WithDefault(t *testing.T) {
+	defaultID := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster"
+	tools := RegisterKubectlTools("readonly", true, true, defaultID)
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	schemaBytes, _ := json.Marshal(tools[0].InputSchema)
+	var schema struct {
+		Required []string `json:"required"`
+	}
+	_ = json.Unmarshal(schemaBytes, &schema)
+
+	for _, r := range schema.Required {
+		if r == "aks_resource_id" {
+			t.Error("aks_resource_id should be optional when default resource ID is provided")
+		}
+	}
+}

--- a/internal/k8s/runcommand_executor.go
+++ b/internal/k8s/runcommand_executor.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -23,10 +24,11 @@ func NewRunCommandExecutor() *RunCommandExecutor {
 }
 
 type RequestContext struct {
-	AzureToken     string `json:"azure_token"`
-	SubscriptionID string `json:"subscription_id"`
-	ResourceGroup  string `json:"resource_group"`
-	ClusterName    string `json:"cluster_name"`
+	AzureToken        string `json:"azure_token"`
+	AzureClusterToken string `json:"azure_cluster_token"`
+	SubscriptionID    string `json:"subscription_id"`
+	ResourceGroup     string `json:"resource_group"`
+	ClusterName       string `json:"cluster_name"`
 }
 
 func extractRequestContext(c context.Context, params map[string]interface{}) (*RequestContext, error) {
@@ -38,10 +40,18 @@ func extractRequestContext(c context.Context, params map[string]interface{}) (*R
 	var reqCtx RequestContext
 	reqCtx.AzureToken = tokenStr
 
-	// Extract aks_resource_id from params
-	aksResourceID, ok := params["aks_resource_id"].(string)
-	if !ok || aksResourceID == "" {
-		return nil, fmt.Errorf("aks_resource_id not found in params or empty")
+	// Cluster token is optional — only required for AAD + Kubernetes RBAC clusters.
+	if clusterToken, ok := c.Value(ctx.AzureClusterTokenKey).(string); ok {
+		reqCtx.AzureClusterToken = clusterToken
+	}
+
+	// Extract aks_resource_id from params, falling back to the configured default
+	aksResourceID, _ := params["aks_resource_id"].(string)
+	if aksResourceID == "" {
+		aksResourceID = os.Getenv("AZURE_AKS_RESOURCE_ID")
+	}
+	if aksResourceID == "" {
+		return nil, fmt.Errorf("aks_resource_id not found in params and AZURE_AKS_RESOURCE_ID is not set")
 	}
 
 	// Parse Azure Resource ID: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{cluster}
@@ -98,8 +108,16 @@ func (e *RunCommandExecutor) Execute(ctx context.Context, params map[string]inte
 
 	managedClustersClient := clientFactory.NewManagedClustersClient()
 
+	// For AAD + Kubernetes RBAC clusters a dedicated cluster token is required.
+	// For Azure RBAC clusters the ARM token doubles as the cluster token.
+	clusterToken := reqCtx.AzureClusterToken
+	if clusterToken == "" {
+		clusterToken = reqCtx.AzureToken
+	}
+
 	runCommandRequest := armcontainerservice.RunCommandRequest{
-		Command: &command,
+		Command:      &command,
+		ClusterToken: &clusterToken,
 	}
 
 	poller, err := managedClustersClient.BeginRunCommand(ctx, reqCtx.ResourceGroup, reqCtx.ClusterName, runCommandRequest, nil)

--- a/internal/k8s/runcommand_executor_test.go
+++ b/internal/k8s/runcommand_executor_test.go
@@ -75,6 +75,8 @@ func TestExtractRequestContext_EmptyToken(t *testing.T) {
 }
 
 func TestExtractRequestContext_MissingResourceID(t *testing.T) {
+	t.Setenv("AZURE_AKS_RESOURCE_ID", "") // ensure env var doesn't mask the error
+
 	c := context.WithValue(context.Background(), ctx.AzureTokenKey, "test-token-123")
 
 	params := map[string]interface{}{}
@@ -84,13 +86,15 @@ func TestExtractRequestContext_MissingResourceID(t *testing.T) {
 		t.Fatal("Expected error for missing resource ID, got nil")
 	}
 
-	expectedMsg := "aks_resource_id not found in params or empty"
+	expectedMsg := "aks_resource_id not found in params and AZURE_AKS_RESOURCE_ID is not set"
 	if err.Error() != expectedMsg {
 		t.Errorf("Expected error '%s', got '%s'", expectedMsg, err.Error())
 	}
 }
 
 func TestExtractRequestContext_EmptyResourceID(t *testing.T) {
+	t.Setenv("AZURE_AKS_RESOURCE_ID", "") // ensure env var doesn't mask the error
+
 	c := context.WithValue(context.Background(), ctx.AzureTokenKey, "test-token-123")
 
 	params := map[string]interface{}{
@@ -102,7 +106,7 @@ func TestExtractRequestContext_EmptyResourceID(t *testing.T) {
 		t.Fatal("Expected error for empty resource ID, got nil")
 	}
 
-	expectedMsg := "aks_resource_id not found in params or empty"
+	expectedMsg := "aks_resource_id not found in params and AZURE_AKS_RESOURCE_ID is not set"
 	if err.Error() != expectedMsg {
 		t.Errorf("Expected error '%s', got '%s'", expectedMsg, err.Error())
 	}
@@ -230,6 +234,8 @@ func TestExecute_MissingContext(t *testing.T) {
 }
 
 func TestExecute_InvalidParams(t *testing.T) {
+	t.Setenv("AZURE_AKS_RESOURCE_ID", "") // ensure env var doesn't interfere
+
 	executor := &RunCommandExecutor{}
 
 	c := context.WithValue(context.Background(), ctx.AzureTokenKey, "test-token-123")
@@ -244,7 +250,7 @@ func TestExecute_InvalidParams(t *testing.T) {
 			params: map[string]interface{}{
 				"command": "kubectl get pods",
 			},
-			expectedErr: "failed to extract request context: aks_resource_id not found in params or empty",
+			expectedErr: "failed to extract request context: aks_resource_id not found in params and AZURE_AKS_RESOURCE_ID is not set",
 		},
 		{
 			name: "Invalid aks_resource_id",
@@ -573,5 +579,88 @@ func TestValidateCommand_Combined(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestExtractRequestContext_WithClusterToken(t *testing.T) {
+	c := context.WithValue(context.Background(), ctx.AzureTokenKey, "arm-token")
+	c = context.WithValue(c, ctx.AzureClusterTokenKey, "cluster-token-abc")
+
+	params := map[string]interface{}{
+		"aks_resource_id": "/subscriptions/sub-123/resourceGroups/rg-test/providers/Microsoft.ContainerService/managedClusters/cluster-test",
+	}
+
+	reqCtx, err := extractRequestContext(c, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reqCtx.AzureClusterToken != "cluster-token-abc" {
+		t.Errorf("expected cluster-token-abc, got %q", reqCtx.AzureClusterToken)
+	}
+}
+
+func TestExtractRequestContext_ClusterTokenAbsentIsEmpty(t *testing.T) {
+	c := context.WithValue(context.Background(), ctx.AzureTokenKey, "arm-token")
+
+	params := map[string]interface{}{
+		"aks_resource_id": "/subscriptions/sub-123/resourceGroups/rg-test/providers/Microsoft.ContainerService/managedClusters/cluster-test",
+	}
+
+	reqCtx, err := extractRequestContext(c, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reqCtx.AzureClusterToken != "" {
+		t.Errorf("expected empty cluster token when not in context, got %q", reqCtx.AzureClusterToken)
+	}
+}
+
+func TestExtractRequestContext_EnvVarFallbackForResourceID(t *testing.T) {
+	t.Setenv("AZURE_AKS_RESOURCE_ID", "/subscriptions/env-sub/resourceGroups/env-rg/providers/Microsoft.ContainerService/managedClusters/env-cluster")
+
+	c := context.WithValue(context.Background(), ctx.AzureTokenKey, "arm-token")
+	params := map[string]interface{}{} // no aks_resource_id in params
+
+	reqCtx, err := extractRequestContext(c, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reqCtx.SubscriptionID != "env-sub" {
+		t.Errorf("expected env-sub from env var, got %q", reqCtx.SubscriptionID)
+	}
+	if reqCtx.ResourceGroup != "env-rg" {
+		t.Errorf("expected env-rg from env var, got %q", reqCtx.ResourceGroup)
+	}
+	if reqCtx.ClusterName != "env-cluster" {
+		t.Errorf("expected env-cluster from env var, got %q", reqCtx.ClusterName)
+	}
+}
+
+func TestExtractRequestContext_ParamTakesPrecedenceOverEnvVar(t *testing.T) {
+	t.Setenv("AZURE_AKS_RESOURCE_ID", "/subscriptions/env-sub/resourceGroups/env-rg/providers/Microsoft.ContainerService/managedClusters/env-cluster")
+
+	c := context.WithValue(context.Background(), ctx.AzureTokenKey, "arm-token")
+	params := map[string]interface{}{
+		"aks_resource_id": "/subscriptions/param-sub/resourceGroups/param-rg/providers/Microsoft.ContainerService/managedClusters/param-cluster",
+	}
+
+	reqCtx, err := extractRequestContext(c, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reqCtx.SubscriptionID != "param-sub" {
+		t.Errorf("param should take precedence over env var, got %q", reqCtx.SubscriptionID)
+	}
+}
+
+func TestExtractRequestContext_NoResourceIDAnywhere(t *testing.T) {
+	t.Setenv("AZURE_AKS_RESOURCE_ID", "")
+
+	c := context.WithValue(context.Background(), ctx.AzureTokenKey, "arm-token")
+	params := map[string]interface{}{}
+
+	_, err := extractRequestContext(c, params)
+	if err == nil {
+		t.Fatal("expected error when no resource ID in params or env var")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -532,7 +532,7 @@ func (s *Service) registerKubectlComponent() {
 	}
 
 	// Get kubectl tools filtered by access level and tool type
-	kubectlTools := k8s.RegisterKubectlTools(s.cfg.AccessLevel, useUnifiedTool, s.cfg.TokenAuthOnly)
+	kubectlTools := k8s.RegisterKubectlTools(s.cfg.AccessLevel, useUnifiedTool, s.cfg.TokenAuthOnly, s.cfg.DefaultAKSResourceID)
 
 	// Create a kubectl executor
 	kubectlExecutor := kubectl.NewKubectlToolExecutor()


### PR DESCRIPTION
## Summary
                                                                                                                                                                         
Browser-based MCP clients such as Claude Web authenticate via OAuth but cannot supply the `X-Azure-Token` header required by `tokenAuthOnly` kubectl tools, causing all `call_kubectl` invocations to fail with `X-Azure-Token not found in context`. This PR adds an On-Behalf-Of (OBO) token exchange flow that resolves this entirely server-side with no changes required from the client.                                                                                                                  
                                                                                                                                                                         
  ### Changes                                                                                                                                                            

  **On-Behalf-Of token exchange (`--oauth-obo-enabled`)**                                                                                                                
  - After OAuth validates the user's bearer token, the server performs two OBO exchanges via Azure AD: one for an ARM token (`https://management.azure.com/user_impersonation`) used to authenticate the RunCommand API call, and one for an AKS cluster token (`6dae42f8-4368-4678-94ff-3960e28e3630`) required by AAD-enabled clusters using Kubernetes RBAC
  - Both tokens are injected into the request context automatically — `call_kubectl` finds them without any client-side changes                                          
  - Falls back gracefully: if the cluster OBO exchange fails (e.g. Azure RBAC cluster), the ARM token is used as the cluster token                                       
                                                                                                                                                                         
  **Session caching**                                                                                                                                                    
  - Browser clients authenticate once and then send only `Mcp-Session-Id` on follow-up requests with no `Authorization` header. The middleware now caches OBO tokens per session so these continuation requests succeed                                                                                                                         
  - OBO tokens are refreshed proactively 5 minutes before expiry using the cached bearer token, keeping sessions alive without prompting the user to reconnect
  - Sessions are bounded by the bearer token's lifetime (up to 24 hours)                                                                                                 
                                                                                                                                                                         
  **Default cluster resource ID (`--default-aks-resource-id` / `AZURE_AKS_RESOURCE_ID`)**                                                                                
  - When a default cluster is configured, `aks_resource_id` becomes optional in the `call_kubectl` tool schema — MCP clients no longer ask the user to supply the cluster resource ID on every conversation

**Helm chart**

One new value:

  ```yaml

  oauth:
    oboEnabled: false          # new — enable OBO flow
```

**Azure AD requirements**

The app registration requires the Azure Service Management → user_impersonation delegated permission and a client secret (passed via AZURE_CLIENT_SECRET / azure.clientSecret).
                                                                                                                                                                         
**Backwards compatibility**                                                                                                                                         
   
All new behaviour is gated behind --oauth-obo-enabled (default: false). Existing deployments using workload identity, local az login, or manual X-Azure-Token headers are completely unaffected.                                
                                                                                                                                                                         