### PR TITLE
docs: clarify supported deployment model and security boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ is the only deployment model the project supports and hardens for.
 
 ### The trust boundary
 
-AKS-MCP executes Azure CLI and `kubectl` commands **using the identity of the
-process it runs as**. It does not perform per-caller authorization, and it does
-not attempt to sandbox the commands it runs. Therefore:
+AKS-MCP executes command-line tools — including `az`, `kubectl`, `helm`,
+`cilium`, and `hubble` — **using the identity of the process it runs as**. It
+does not perform per-caller authorization, and it does not attempt to sandbox
+the commands it runs. Therefore:
 
 > **Anyone who can invoke AKS-MCP tools effectively has the full Azure and
 > Kubernetes privileges of the identity AKS-MCP is running under.**
@@ -31,8 +32,10 @@ not attempt to sandbox the commands it runs. Therefore:
 This includes the ability to obtain reusable credentials. For example, in
 `readwrite` or `admin` mode a caller can issue Azure CLI commands that return
 Azure Resource Manager bearer tokens or AKS kubeconfig material, and then use
-those credentials outside of AKS-MCP. This is an inherent consequence of
-exposing a CLI execution surface — it is not prevented by `--access-level`.
+those credentials outside of AKS-MCP. Similarly, `kubectl` and `helm` can be
+used to read Secrets or deploy arbitrary workloads into the cluster. This is an
+inherent consequence of exposing a CLI execution surface — it is not prevented
+by `--access-level`.
 
 **Treat the ability to call AKS-MCP as equivalent to handing over a shell that
 is already logged in as the server identity.**

--- a/README.md
+++ b/README.md
@@ -30,12 +30,18 @@ the commands it runs. Therefore:
 > Kubernetes privileges of the identity AKS-MCP is running under.**
 
 This includes the ability to obtain reusable credentials. For example, in
-`readwrite` or `admin` mode a caller can issue Azure CLI commands that return
-Azure Resource Manager bearer tokens or AKS kubeconfig material, and then use
-those credentials outside of AKS-MCP. Similarly, `kubectl` and `helm` can be
-used to read Secrets or deploy arbitrary workloads into the cluster. This is an
-inherent consequence of exposing a CLI execution surface — it is not prevented
-by `--access-level`.
+`readwrite` or `admin` mode a caller can reach Azure Resource Manager and AKS
+with the server identity's full authority, and `kubectl` or `helm` can be used
+to read Secrets, mint service account tokens, or deploy arbitrary workloads
+into the cluster. This is an inherent consequence of exposing a CLI execution
+surface — it is not prevented by `--access-level`.
+
+Specific credential-returning Azure CLI commands (such as
+`az account get-access-token` and `az aks get-credentials`) are rejected by an
+explicit denylist. That denylist reduces accidental exposure — it is **not** a
+security boundary, it does not cover the `kubectl`, `helm`, `cilium`, or
+`hubble` surfaces, and it must not be relied upon to contain an untrusted
+caller.
 
 **Treat the ability to call AKS-MCP as equivalent to handing over a shell that
 is already logged in as the server identity.**
@@ -573,8 +579,9 @@ If you see "spawn ENOENT" errors, verify your VS Code environment:
 > **Outside the supported deployment model.** In-cluster / remote deployment
 > is not the intended usage of AKS-MCP and is not hardened for it. Every caller
 > that can reach the endpoint inherits the full Azure and Kubernetes privileges
-> of the server identity, including the ability to extract reusable credentials.
-> `--access-level` does not prevent this. If you proceed, you must enable OAuth,
+> of the server identity. `--access-level` and the credential-command denylist
+> reduce accidental damage but are not security boundaries against a malicious
+> caller. If you proceed, you must enable OAuth,
 > restrict network reachability, and use a dedicated least-privileged identity.
 > See [Supported Deployment Model and Security Considerations](#supported-deployment-model-and-security-considerations).
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,67 @@ It allows AI tools to:
 - Retrieve details related to AKS clusters (VNets, Subnets, NSGs, Route Tables, etc.)
 - Manage Azure Fleet operations for multi-cluster scenarios
 
+## Supported Deployment Model and Security Considerations
+
+**AKS-MCP is designed to be run locally, by a single trusted user, as a bridge
+between that user's own AI assistant and their own Azure/AKS resources.** This
+is the only deployment model the project supports and hardens for.
+
+### The trust boundary
+
+AKS-MCP executes Azure CLI and `kubectl` commands **using the identity of the
+process it runs as**. It does not perform per-caller authorization, and it does
+not attempt to sandbox the commands it runs. Therefore:
+
+> **Anyone who can invoke AKS-MCP tools effectively has the full Azure and
+> Kubernetes privileges of the identity AKS-MCP is running under.**
+
+This includes the ability to obtain reusable credentials. For example, in
+`readwrite` or `admin` mode a caller can issue Azure CLI commands that return
+Azure Resource Manager bearer tokens or AKS kubeconfig material, and then use
+those credentials outside of AKS-MCP. This is an inherent consequence of
+exposing a CLI execution surface — it is not prevented by `--access-level`.
+
+**Treat the ability to call AKS-MCP as equivalent to handing over a shell that
+is already logged in as the server identity.**
+
+### What `--access-level` is and is not
+
+`--access-level` (`readonly` / `readwrite` / `admin`) is a **guardrail to reduce
+accidental damage** from an AI assistant that misinterprets a request. It is
+**not** a security boundary against a deliberately malicious caller, and it must
+not be relied upon to contain an untrusted party. Do not expose AKS-MCP to
+callers you would not grant the underlying Azure/Kubernetes credentials to
+directly.
+
+### Recommended (supported) setup
+
+- Run with `--transport stdio`, launched on demand by your local MCP client.
+- Authenticate with your own developer identity via `az login`.
+- Grant the identity only the Azure/Kubernetes permissions you actually need.
+
+### If you deploy remotely anyway
+
+The `sse` and `streamable-http` transports and the Helm chart exist for
+specific advanced scenarios, but they move AKS-MCP outside its intended usage.
+If you use them, **you own the resulting risk**, and you must at minimum:
+
+- **Require authentication.** Enable OAuth
+  (see [OAuth Authentication](docs/oauth-authentication.md)). Never expose an
+  unauthenticated endpoint.
+- **Restrict network exposure.** Do not publish the endpoint to the internet or
+  to a shared network. Bind to loopback, or place it behind network policy /
+  private networking so that only intended callers can reach it.
+- **Minimize the server identity's permissions.** Assume every caller inherits
+  them in full. Use a dedicated, least-privileged identity scoped to a single
+  subscription or resource group — never a broadly privileged one.
+- **Do not treat it as multi-tenant.** AKS-MCP cannot separate one caller's
+  authority from another's; all callers share the single server identity.
+
+Browser-originated requests are a particular concern: a malicious web page can
+attempt to reach a locally or privately bound HTTP endpoint. Authentication and
+network isolation are the mitigations.
+
 ## How it works
 
 AKS-MCP connects to Azure using the Azure SDK and provides a set of tools that
@@ -505,6 +566,15 @@ If you see "spawn ENOENT" errors, verify your VS Code environment:
 
 
 ### Deploy the MCP server in-cluster (Remote MCP)
+
+> **Outside the supported deployment model.** In-cluster / remote deployment
+> is not the intended usage of AKS-MCP and is not hardened for it. Every caller
+> that can reach the endpoint inherits the full Azure and Kubernetes privileges
+> of the server identity, including the ability to extract reusable credentials.
+> `--access-level` does not prevent this. If you proceed, you must enable OAuth,
+> restrict network reachability, and use a dedicated least-privileged identity.
+> See [Supported Deployment Model and Security Considerations](#supported-deployment-model-and-security-considerations).
+
 <details>
 <summary> Remote MCP Installation </summary>
 To enable the remote AKS MCP server in your AKS cluster, see the instructions below:

--- a/chart/README.md
+++ b/chart/README.md
@@ -8,14 +8,15 @@ AKS-MCP is designed to be run **locally by a single trusted user** over the
 `stdio` transport. Deploying it into a cluster as a shared, network-reachable
 service is **outside its intended usage** and is not hardened for that scenario.
 
-AKS-MCP runs Azure CLI and `kubectl` commands using the identity of the pod it
-runs in, and does not perform per-caller authorization:
+AKS-MCP runs `az`, `kubectl`, `helm`, and related CLI tools using the identity
+of the pod it runs in, and does not perform per-caller authorization:
 
 > **Anyone who can reach this endpoint effectively holds the full Azure and
-> Kubernetes privileges of the deployed identity** — including the ability to
-> retrieve reusable ARM bearer tokens and AKS kubeconfig material and use them
-> elsewhere. `--access-level readonly` is an accident-prevention guardrail, not
-> a security boundary against a malicious caller.
+> Kubernetes privileges of the deployed identity** — including reading Secrets,
+> minting service account tokens, and deploying arbitrary workloads.
+> `--access-level readonly` and the Azure CLI credential-command denylist are
+> accident-prevention guardrails, not security boundaries against a malicious
+> caller.
 
 If you still choose to deploy this chart, you must:
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -2,6 +2,33 @@
 
 This Helm chart deploys AKS-MCP (Azure Kubernetes Service Model Context Protocol) server on Kubernetes clusters.
 
+## Read this before deploying
+
+AKS-MCP is designed to be run **locally by a single trusted user** over the
+`stdio` transport. Deploying it into a cluster as a shared, network-reachable
+service is **outside its intended usage** and is not hardened for that scenario.
+
+AKS-MCP runs Azure CLI and `kubectl` commands using the identity of the pod it
+runs in, and does not perform per-caller authorization:
+
+> **Anyone who can reach this endpoint effectively holds the full Azure and
+> Kubernetes privileges of the deployed identity** — including the ability to
+> retrieve reusable ARM bearer tokens and AKS kubeconfig material and use them
+> elsewhere. `--access-level readonly` is an accident-prevention guardrail, not
+> a security boundary against a malicious caller.
+
+If you still choose to deploy this chart, you must:
+
+- **Enable OAuth.** Never expose an unauthenticated endpoint.
+- **Restrict network reachability** (NetworkPolicy, private/internal Service —
+  do not expose it to the internet or a shared network).
+- **Use a dedicated, least-privileged identity**, scoped as narrowly as
+  possible. Assume every caller inherits it in full.
+- **Not treat it as multi-tenant.** All callers share one server identity.
+
+See [Supported Deployment Model and Security Considerations](../README.md#supported-deployment-model-and-security-considerations)
+for details.
+
 ## Prerequisites
 
 - Kubernetes 1.19+


### PR DESCRIPTION
  ## Summary

  Documents that AKS-MCP is intended for **local, single trusted user** use over `stdio`, and states its security boundary explicitly. This addresses the
  DevSec recommendation to clearly call out the supported deployment model and warn users of the consequences of deviating from it.

  Documentation only — no code or behavior changes.

  - **README.md**: new `Supported Deployment Model and Security Considerations` section near the top, covering:
    - the trust boundary — AKS-MCP shells out to `az`, `kubectl`, `helm`, `cilium`, and `hubble` under the identity of its own process and does no
  per-caller authorization, so **any caller effectively holds that identity's full Azure and Kubernetes privileges**, including obtaining reusable ARM
  tokens and kubeconfig material, reading Secrets, or deploying arbitrary workloads
    - that `--access-level` is a guardrail against accidental damage from an AI assistant misinterpreting a request, **not** a boundary against a
  deliberately malicious caller
    - the recommended (supported) setup, and hardening requirements for anyone deploying remotely anyway: OAuth, restricted network reachability, a
  dedicated least-privileged identity, and that it is not multi-tenant
  - **README.md**: warning callout on the in-cluster / Remote MCP install section
  - **chart/README.md**: equivalent warning at the top, since the Helm chart is the most likely entry point to be misread as an endorsement of shared
  deployment

  ## Why

  The SSE / streamable-http transports and the Helm chart could reasonably be read as endorsing shared, network-reachable deployment. The project is not
  hardened for that model, and this gap was not stated anywhere. Wording is framed as defining the supported model and giving correct guidance for advanced
  scenarios, rather than as a retroactive restriction.

  ## Test plan

  - [ ] Rendered README section reads clearly and is visible without scrolling past the feature list
  - [ ] Anchor link `#supported-deployment-model-and-security-considerations` resolves from both the Remote MCP callout and `chart/README.md`
  - [ ] Relative link from `chart/README.md` to `../README.md` resolves on GitHub