### PR TITLE
Enforce the local-only MCP contract

### DIFF
--- a/cmd/aks-mcp/main_test.go
+++ b/cmd/aks-mcp/main_test.go
@@ -7,21 +7,40 @@ import (
 	"testing"
 )
 
-func TestRemovedHTTPFlagsAreRejected(t *testing.T) {
+func TestLocalTransportContract(t *testing.T) {
 	binary := filepath.Join(t.TempDir(), "aks-mcp")
 	build := exec.Command("go", "build", "-o", binary, ".")
 	if output, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("build command failed: %v\n%s", err, output)
 	}
 
-	for _, removedFlag := range []string{"--transport=sse", "--host=127.0.0.1", "--port=8000", "--oauth-enabled"} {
-		command := exec.Command(binary, removedFlag)
+	for _, args := range [][]string{
+		{"--transport", "stdio", "--version"},
+		{"--transport=stdio", "--version"},
+	} {
+		command := exec.Command(binary, args...)
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Errorf("%v returned error: %v\n%s", args, err, output)
+		}
+	}
+
+	rejected := []struct {
+		flag       string
+		wantOutput string
+	}{
+		{flag: "--transport=sse", wantOutput: `unsupported transport "sse": only stdio is supported`},
+		{flag: "--host=127.0.0.1", wantOutput: "unknown flag"},
+		{flag: "--port=8000", wantOutput: "unknown flag"},
+		{flag: "--oauth-enabled", wantOutput: "unknown flag"},
+	}
+	for _, tt := range rejected {
+		command := exec.Command(binary, tt.flag)
 		output, err := command.CombinedOutput()
 		if err == nil {
-			t.Fatalf("%s unexpectedly succeeded", removedFlag)
+			t.Fatalf("%s unexpectedly succeeded", tt.flag)
 		}
-		if !strings.Contains(string(output), "unknown flag") {
-			t.Errorf("%s returned unexpected output:\n%s", removedFlag, output)
+		if !strings.Contains(string(output), tt.wantOutput) {
+			t.Errorf("%s returned unexpected output:\n%s", tt.flag, output)
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,31 +47,44 @@ func NewConfig() *ConfigData {
 
 // ParseFlags parses command line arguments and updates the configuration.
 func (cfg *ConfigData) ParseFlags() {
-	flag.IntVar(&cfg.Timeout, "timeout", 600, "Timeout for command execution in seconds, default is 600s")
-	flag.StringVar(&cfg.AccessLevel, "access-level", "readonly", "Access level (readonly, readwrite, admin)")
-	enabledComponents := flag.String("enabled-components", "", "Comma-separated list of enabled components (empty means all components enabled). Available: az_cli,monitor,fleet,network,compute,detectors,advisor,inspektorgadget,kubectl,helm,cilium,hubble")
-	flag.StringVar(&cfg.AllowNamespaces, "allow-namespaces", "", "Comma-separated list of allowed Kubernetes namespaces (empty means all namespaces)")
-	flag.StringVar(&cfg.DefaultAKSResourceID, "default-aks-resource-id", "", "Default AKS cluster resource ID used when aks_resource_id is not supplied by the caller (e.g. /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{cluster}). Falls back to AZURE_AKS_RESOURCE_ID env var.")
-	flag.StringVar(&cfg.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
-	flag.StringVar(&cfg.OTLPEndpoint, "otlp-endpoint", "", "OTLP endpoint for OpenTelemetry traces (e.g. localhost:4317)")
-
-	var showHelp bool
-	flag.BoolVarP(&showHelp, "help", "h", false, "Show help message")
-	showVersion := flag.Bool("version", false, "Show version information and exit")
-
-	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
+	flags, showHelp, showVersion, err := cfg.parseFlags(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		fmt.Printf("\nUsage of %s:\n", os.Args[0])
-		flag.PrintDefaults()
+		flags.PrintDefaults()
 		os.Exit(1)
 	}
 	if showHelp {
 		fmt.Printf("Usage of %s:\n", os.Args[0])
-		flag.PrintDefaults()
+		flags.PrintDefaults()
 		os.Exit(0)
 	}
-	if *showVersion {
+	if showVersion {
 		cfg.PrintVersion()
 		os.Exit(0)
+	}
+}
+
+func (cfg *ConfigData) parseFlags(args []string) (*flag.FlagSet, bool, bool, error) {
+	flags := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flags.IntVar(&cfg.Timeout, "timeout", 600, "Timeout for command execution in seconds, default is 600s")
+	flags.StringVar(&cfg.AccessLevel, "access-level", "readonly", "Access level (readonly, readwrite, admin)")
+	enabledComponents := flags.String("enabled-components", "", "Comma-separated list of enabled components (empty means all components enabled). Available: az_cli,monitor,fleet,network,compute,detectors,advisor,inspektorgadget,kubectl,helm,cilium,hubble")
+	flags.StringVar(&cfg.AllowNamespaces, "allow-namespaces", "", "Comma-separated list of allowed Kubernetes namespaces (empty means all namespaces)")
+	flags.StringVar(&cfg.DefaultAKSResourceID, "default-aks-resource-id", "", "Default AKS cluster resource ID used when aks_resource_id is not supplied by the caller (e.g. /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{cluster}). Falls back to AZURE_AKS_RESOURCE_ID env var.")
+	flags.StringVar(&cfg.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
+	flags.StringVar(&cfg.OTLPEndpoint, "otlp-endpoint", "", "OTLP endpoint for OpenTelemetry traces (e.g. localhost:4317)")
+	transport := flags.String("transport", "stdio", "Transport type (stdio only; retained for local client compatibility)")
+
+	var showHelp bool
+	flags.BoolVarP(&showHelp, "help", "h", false, "Show help message")
+	showVersion := flags.Bool("version", false, "Show version information and exit")
+
+	if err := flags.Parse(args); err != nil {
+		return flags, false, false, err
+	}
+	if *transport != "stdio" {
+		return flags, false, false, fmt.Errorf("unsupported transport %q: only stdio is supported", *transport)
 	}
 
 	cfg.SecurityConfig.AccessLevel = cfg.AccessLevel
@@ -86,6 +99,8 @@ func (cfg *ConfigData) ParseFlags() {
 			}
 		}
 	}
+
+	return flags, showHelp, *showVersion, nil
 }
 
 // InitializeTelemetry initializes the telemetry service.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseFlagsAcceptsStdioTransportCompatibility(t *testing.T) {
+	tests := [][]string{
+		{"--transport", "stdio"},
+		{"--transport=stdio"},
+	}
+
+	for _, args := range tests {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			cfg := NewConfig()
+			if _, _, _, err := cfg.parseFlags(args); err != nil {
+				t.Fatalf("parseFlags(%q) returned error: %v", args, err)
+			}
+		})
+	}
+}
+
+func TestParseFlagsRejectsRemoteTransportAndListenerOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "http transport", args: []string{"--transport", "http"}, wantErr: `unsupported transport "http": only stdio is supported`},
+		{name: "sse transport", args: []string{"--transport=sse"}, wantErr: `unsupported transport "sse": only stdio is supported`},
+		{name: "streamable transport", args: []string{"--transport", "streamable-http"}, wantErr: `unsupported transport "streamable-http": only stdio is supported`},
+		{name: "host", args: []string{"--host", "127.0.0.1"}, wantErr: "unknown flag: --host"},
+		{name: "port", args: []string{"--port", "8080"}, wantErr: "unknown flag: --port"},
+		{name: "oauth", args: []string{"--oauth-enabled"}, wantErr: "unknown flag: --oauth-enabled"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig()
+			_, _, _, err := cfg.parseFlags(tt.args)
+			if err == nil {
+				t.Fatalf("parseFlags(%q) succeeded, expected an error", tt.args)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("parseFlags(%q) error = %q, want it to contain %q", tt.args, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -47,4 +49,79 @@ func TestParseFlagsRejectsRemoteTransportAndListenerOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseFlagsObservableOutcomes(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantExit   int
+		wantOutput []string
+	}{
+		{
+			name:       "help",
+			args:       []string{"--help"},
+			wantExit:   0,
+			wantOutput: []string{"Usage of aks-mcp:", "--transport string", "stdio only"},
+		},
+		{
+			name:       "version",
+			args:       []string{"--version"},
+			wantExit:   0,
+			wantOutput: []string{"aks-mcp version", "Git commit:", "Platform:"},
+		},
+		{
+			name:       "unsupported transport",
+			args:       []string{"--transport=sse"},
+			wantExit:   1,
+			wantOutput: []string{`unsupported transport "sse": only stdio is supported`, "Usage of aks-mcp:", "--transport string"},
+		},
+		{
+			name:       "removed listener option",
+			args:       []string{"--host=127.0.0.1"},
+			wantExit:   1,
+			wantOutput: []string{"unknown flag: --host", "Usage of aks-mcp:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append([]string{"-test.run=TestParseFlagsProcess", "--"}, tt.args...)
+			command := exec.Command(os.Args[0], args...)
+			command.Env = append(os.Environ(), "GO_WANT_PARSE_FLAGS_PROCESS=1")
+			output, err := command.CombinedOutput()
+
+			if tt.wantExit == 0 {
+				if err != nil {
+					t.Fatalf("ParseFlags(%q) returned error: %v\n%s", tt.args, err, output)
+				}
+			} else {
+				exitErr, ok := err.(*exec.ExitError)
+				if !ok || exitErr.ExitCode() != tt.wantExit {
+					t.Fatalf("ParseFlags(%q) exit error = %v, want exit code %d\n%s", tt.args, err, tt.wantExit, output)
+				}
+			}
+			for _, want := range tt.wantOutput {
+				if !strings.Contains(string(output), want) {
+					t.Errorf("ParseFlags(%q) output does not contain %q:\n%s", tt.args, want, output)
+				}
+			}
+		})
+	}
+}
+
+func TestParseFlagsProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_PARSE_FLAGS_PROCESS") != "1" {
+		return
+	}
+
+	separator := 0
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	os.Args = append([]string{"aks-mcp"}, os.Args[separator+1:]...)
+	NewConfig().ParseFlags()
 }

--- a/internal/prompts/cluster.go
+++ b/internal/prompts/cluster.go
@@ -22,11 +22,9 @@ This guide will help you query AKS cluster metadata (subscriptionID, resourceGro
 
 ### 1. Retrieve the control plane FQDN:
 
-Invoke the kubectl_cluster MCP tool with inputs:
+Invoke the call_kubectl MCP tool with inputs:
 	{
-		"operation": "cluster-info",
-		"resource": "",
-		"args": ""
+		"command": "kubectl cluster-info"
 	}
 
 
@@ -34,10 +32,9 @@ This will show the Kubernetes control plane endpoint URL (FQDN).
 
 ### 2. List available AKS clusters in your subscription
 
-Invoke the az_aks_operations MCP tool with inputs:
+Invoke the call_az MCP tool with inputs:
 	{
-		"operation": "list",
-		"args": "--query "[].{id:id, fqdn:fqdn}" -o json"
+		"cli_command": "az aks list --query \"[].{id:id, fqdn:fqdn}\" -o json"
 	}
 
 This will show all the AKS clusters (in JSON format) in user pre-configured subscription.

--- a/internal/prompts/health.go
+++ b/internal/prompts/health.go
@@ -21,19 +21,16 @@ This guide performs a thorough health evaluation of your AKS cluster across mult
 ## Steps
 
 ### 1. Retrieve Control Plane FQDN
-Invoke kubectl_cluster tool:
+Invoke call_kubectl tool:
 {
-  "operation": "cluster-info",
-  "resource": "",
-  "args": ""
+  "command": "kubectl cluster-info"
 }
 Extract the Kubernetes control plane endpoint URL (FQDN) for cluster identification.
 
 ### 2. Identify AKS Cluster Metadata
-Invoke az_aks_operations tool:
+Invoke call_az tool:
 {
-  "operation": "list",
-  "args": "--query \"[].{id:id, fqdn:fqdn, resourceGroup:resourceGroup, name:name}\" -o json"
+  "cli_command": "az aks list --query \"[].{id:id, fqdn:fqdn, resourceGroup:resourceGroup, name:name}\" -o json"
 }
 Match the control plane FQDN from Step 1 with the cluster list to determine subscription ID, resource group, and cluster name. Extract the full AKS resource ID for subsequent steps.
 
@@ -49,9 +46,10 @@ Invoke aks_monitoring tool:
 Analyze: Identify any Azure platform incidents, service health issues, or resource degradation events that may impact cluster availability.
 
 ### 4. Run Cluster and Control Plane Availability Detectors
-Invoke run_detectors_by_category tool:
+Invoke aks_detector tool:
 {
-  "cluster_resource_id": "<AKS_RESOURCE_ID>",
+  "operation": "run_by_category",
+  "aks_resource_id": "<AKS_RESOURCE_ID>",
   "category": "Cluster and Control Plane Availability and Performance",
   "start_time": "<ISO8601_START>",
   "end_time": "<ISO8601_END>"
@@ -59,9 +57,10 @@ Invoke run_detectors_by_category tool:
 Analyze: Review API server responsiveness, control plane scaling issues, etcd health, and cluster networking performance problems.
 
 ### 5. Run Node Health Detectors
-Invoke run_detectors_by_category tool:
+Invoke aks_detector tool:
 {
-  "cluster_resource_id": "<AKS_RESOURCE_ID>",
+  "operation": "run_by_category",
+  "aks_resource_id": "<AKS_RESOURCE_ID>",
   "category": "Node Health",
   "start_time": "<ISO8601_START>",
   "end_time": "<ISO8601_END>"
@@ -69,9 +68,10 @@ Invoke run_detectors_by_category tool:
 Analyze: Examine node readiness issues, kubelet problems, container runtime health, disk pressure, memory pressure, and node pool scaling issues.
 
 ### 6. Run Connectivity Issue Detectors
-Invoke run_detectors_by_category tool:
+Invoke aks_detector tool:
 {
-  "cluster_resource_id": "<AKS_RESOURCE_ID>",
+  "operation": "run_by_category",
+  "aks_resource_id": "<AKS_RESOURCE_ID>",
   "category": "Connectivity Issues",
   "start_time": "<ISO8601_START>",
   "end_time": "<ISO8601_END>"

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -1,0 +1,105 @@
+package prompts_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Azure/aks-mcp/internal/components/detectors"
+	"github.com/Azure/aks-mcp/internal/components/monitor"
+	"github.com/Azure/aks-mcp/internal/config"
+	"github.com/Azure/aks-mcp/internal/k8s"
+	"github.com/Azure/aks-mcp/internal/prompts"
+	azapimcp "github.com/Azure/azure-api-mcp/pkg/azcli"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+var promptToolCallPattern = regexp.MustCompile(`(?s)Invoke (?:the )?([a-z][a-z0-9_]+)(?: MCP)? tool(?: with inputs)?:\s*(\{.*?\n\s*\})`)
+
+func TestShippedPromptsUseDefaultUnifiedToolSchemas(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.UseLegacyTools = false
+
+	promptServer := server.NewMCPServer("prompt-test", "test")
+	prompts.RegisterQueryAKSMetadataFromKubeconfigPrompt(promptServer, cfg)
+	prompts.RegisterHealthPrompts(promptServer, cfg)
+
+	defaultTools := make(map[string]mcp.Tool)
+	for _, tool := range k8s.RegisterKubectlTools(cfg.AccessLevel, true) {
+		defaultTools[tool.Name] = tool
+	}
+	for _, tool := range []mcp.Tool{
+		azapimcp.RegisterCallAzTool(true, ""),
+		monitor.RegisterAksMonitoring(),
+		detectors.RegisterAksDetectorTool(),
+	} {
+		defaultTools[tool.Name] = tool
+	}
+
+	for promptName, registeredPrompt := range promptServer.ListPrompts() {
+		t.Run(promptName, func(t *testing.T) {
+			result, err := registeredPrompt.Handler(context.Background(), mcp.GetPromptRequest{})
+			if err != nil {
+				t.Fatalf("render prompt: %v", err)
+			}
+
+			var callCount int
+			for _, message := range result.Messages {
+				content, ok := message.Content.(mcp.TextContent)
+				if !ok {
+					continue
+				}
+				matches := promptToolCallPattern.FindAllStringSubmatch(content.Text, -1)
+				callCount += len(matches)
+				for _, match := range matches {
+					validatePromptToolCall(t, defaultTools, match[1], match[2])
+				}
+			}
+			if callCount == 0 {
+				t.Fatal("prompt contains no structured tool calls")
+			}
+		})
+	}
+}
+
+func validatePromptToolCall(t *testing.T, defaultTools map[string]mcp.Tool, toolName, rawArguments string) {
+	t.Helper()
+
+	tool, ok := defaultTools[toolName]
+	if !ok {
+		t.Fatalf("prompt references %q, which is not registered in the default unified configuration", toolName)
+	}
+
+	var arguments map[string]any
+	if err := json.Unmarshal([]byte(rawArguments), &arguments); err != nil {
+		t.Fatalf("%s arguments are not valid JSON: %v", toolName, err)
+	}
+
+	for argument := range arguments {
+		if _, ok := tool.InputSchema.Properties[argument]; !ok {
+			t.Errorf("%s prompt argument %q is not defined by the registered tool schema", toolName, argument)
+		}
+	}
+	for _, required := range tool.InputSchema.Required {
+		if _, ok := arguments[required]; !ok {
+			t.Errorf("%s prompt call omits required argument %q", toolName, required)
+		}
+	}
+
+	operation, ok := arguments["operation"].(string)
+	if !ok {
+		return
+	}
+	property, ok := tool.InputSchema.Properties["operation"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s operation schema has unexpected type %T", toolName, tool.InputSchema.Properties["operation"])
+	}
+	description := fmt.Sprint(property["description"])
+	if !strings.Contains(description, operation) {
+		t.Errorf("%s prompt operation %q is not documented by the registered tool schema: %s", toolName, operation, description)
+	}
+}


### PR DESCRIPTION
## Diagnosis

v0.0.20 correctly removed remote transports, but it also dropped the legacy `--transport stdio` invocation still used by [Azure/vscode-aks-tools](https://github.com/Azure/vscode-aks-tools). Both shipped prompts also referenced tools that are unavailable on the default unified tool surface.

## Guiding policy

AKS-MCP is a trusted-local stdio adapter. This change preserves installed local-client compatibility while keeping network exposure impossible, and ensures every workflow advertised by the server is executable against its default unified tools.

## Actions

- Accept `--transport stdio` and `--transport=stdio` as exact compatibility no-ops.
- Reject every non-stdio transport value explicitly; removed listener and auth flags remain rejected.
- Migrate prompts to `call_kubectl`, `call_az`, `aks_monitoring`, and `aks_detector` (`operation=run_by_category`).
- Add binary-level transport tests and structural prompt tests against actual default tool schemas.

## Non-goals

No HTTP, SSE, OAuth, container, or Helm restoration; no new product capability; no telemetry changes or unrelated cleanup.

## Validation

- Targeted config, prompt, kubectl, detector, and monitoring package tests pass.
- The Linux binary test package cross-build passes.
- Independent Claude Opus review **ACCEPTED** immutable commit `c8868df2` after transport edge-case matrix, schema mutation tests, scope review, and parent comparison.
- The repository-wide `go test ./...` run passes all buildable packages on Darwin, then stops at the pre-existing `github.com/inspektor-gadget/inspektor-gadget@v0.50.1` build incompatibility (`unix.CLOCK_BOOTTIME` is undefined). This failure is unrelated to this change.